### PR TITLE
Add support for ssl connections

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,6 +13,8 @@ executors:
         name: faktory_password
         environment:
           - FAKTORY_PASSWORD=very-secret
+      - image: acjensen/faktory-tls
+        name: faktory_tls
 
     working_directory: ~/repo
 

--- a/config/config.exs
+++ b/config/config.exs
@@ -1,42 +1,23 @@
-# This file is responsible for configuring your application
-# and its dependencies with the aid of the Mix.Config module.
 use Mix.Config
 
 if Mix.env() == :test do
   if System.get_env("CI") do
-    config :faktory_worker, :server_passworded,
+    config :faktory_worker, :tls_server,
+      host: "faktory_tls",
+      port: 7419
+
+    config :faktory_worker, :passworded_server,
       host: "faktory_password",
       port: 7419
   else
-    config :faktory_worker, :server_passworded,
+    config :faktory_worker, :tls_server,
+      host: "localhost",
+      port: 7519
+
+    config :faktory_worker, :passworded_server,
       host: "localhost",
       port: 7619
   end
 end
 
-# This configuration is loaded before any dependency and is restricted
-# to this project. If another project depends on this project, this
-# file won't be loaded nor affect the parent project. For this reason,
-# if you want to provide default values for your application for
-# third-party users, it should be done in your "mix.exs" file.
-
-# You can configure your application as:
-#
-#     config :faktory_worker, key: :value
-#
-# and access this configuration in your application as:
-#
-#     Application.get_env(:faktory_worker, :key)
-#
-# You can also configure a third-party app:
-#
-#     config :logger, level: :info
-#
-
-# It is also possible to import configuration files, relative to this
-# directory. For example, you can emulate configuration per environment
-# by uncommenting the line below and defining dev.exs, test.exs and such.
-# Configuration from the imported file will override the ones defined
-# here (which is why it is important to import them last).
-#
-#     import_config "#{Mix.env()}.exs"
+# import_config "#{Mix.env()}.exs"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,6 +4,14 @@ faktory_test:
   ports:
     - "7420:7420"
     - "7419:7419"
+
+faktory_test_tls:
+  container_name: faktory_worker_test_tls
+  image: acjensen/faktory-tls
+  ports:
+    - "7520:7420"
+    - "7519:7419"
+
 faktory_password_test:
   container_name: faktory_worker_password_test
   image: contribsys/faktory:0.9.6

--- a/lib/faktory_worker/socket.ex
+++ b/lib/faktory_worker/socket.ex
@@ -3,7 +3,7 @@ defmodule FaktoryWorker.Socket do
 
   alias FaktoryWorker.Connection
 
-  @callback connect(host :: String.t(), port :: pos_integer()) ::
+  @callback connect(host :: String.t(), port :: pos_integer(), opts :: keyword()) ::
               {:ok, Connection.t()} | {:error, term()}
 
   @callback send(connection :: Connection.t(), payload :: String.t()) ::

--- a/lib/faktory_worker/socket/ssl.ex
+++ b/lib/faktory_worker/socket/ssl.ex
@@ -29,6 +29,7 @@ defmodule FaktoryWorker.Socket.Ssl do
     opts = [
       :binary,
       active: false,
+      packet: :line,
       versions: [:"tlsv1.2"],
       verify: map_tls_verify(tls_verify),
       cacerts: :certifi.cacerts()

--- a/lib/faktory_worker/socket/ssl.ex
+++ b/lib/faktory_worker/socket/ssl.ex
@@ -1,0 +1,42 @@
+defmodule FaktoryWorker.Socket.Ssl do
+  @moduledoc false
+
+  alias FaktoryWorker.Connection
+
+  @behaviour FaktoryWorker.Socket
+
+  @impl true
+  def connect(host, port, opts \\ []) do
+    with {:ok, socket} <- try_connect(host, port, opts) do
+      {:ok, %Connection{host: host, port: port, socket: socket, socket_handler: __MODULE__}}
+    end
+  end
+
+  @impl true
+  def send(%{socket: socket}, payload) do
+    :ssl.send(socket, payload)
+  end
+
+  @impl true
+  def recv(%{socket: socket}) do
+    :ssl.recv(socket, 0)
+  end
+
+  defp try_connect(host, port, opts) do
+    host = String.to_charlist(host)
+    tls_verify = Keyword.get(opts, :tls_verify, true)
+
+    opts = [
+      :binary,
+      active: false,
+      versions: [:"tlsv1.2"],
+      verify: map_tls_verify(tls_verify),
+      cacerts: :certifi.cacerts()
+    ]
+
+    :ssl.connect(host, port, opts)
+  end
+
+  defp map_tls_verify(true), do: :verify_peer
+  defp map_tls_verify(_), do: :verify_none
+end

--- a/lib/faktory_worker/socket/tcp.ex
+++ b/lib/faktory_worker/socket/tcp.ex
@@ -6,7 +6,7 @@ defmodule FaktoryWorker.Socket.Tcp do
   @behaviour FaktoryWorker.Socket
 
   @impl true
-  def connect(host, port) do
+  def connect(host, port, _opts \\ []) do
     with {:ok, socket} <- try_connect(host, port) do
       {:ok, %Connection{host: host, port: port, socket: socket, socket_handler: __MODULE__}}
     end

--- a/mix.exs
+++ b/mix.exs
@@ -23,6 +23,7 @@ defmodule FaktoryWorker.MixProject do
 
   defp deps do
     [
+      {:certifi, "~> 2.5"},
       {:jason, "~> 1.1"},
       {:mox, "~> 0.5", only: :test}
     ]

--- a/mix.lock
+++ b/mix.lock
@@ -1,4 +1,6 @@
 %{
+  "certifi": {:hex, :certifi, "2.5.1", "867ce347f7c7d78563450a18a6a28a8090331e77fa02380b4a21962a65d36ee5", [:rebar3], [{:parse_trans, "~>3.3", [hex: :parse_trans, repo: "hexpm", optional: false]}], "hexpm"},
   "jason": {:hex, :jason, "1.1.2", "b03dedea67a99223a2eaf9f1264ce37154564de899fd3d8b9a21b1a6fd64afe7", [:mix], [{:decimal, "~> 1.0", [hex: :decimal, repo: "hexpm", optional: true]}], "hexpm"},
   "mox": {:hex, :mox, "0.5.0", "c519b48407017a85f03407a9a4c4ceb7cc6dec5fe886b2241869fb2f08476f9e", [:mix], [], "hexpm"},
+  "parse_trans": {:hex, :parse_trans, "3.3.0", "09765507a3c7590a784615cfd421d101aec25098d50b89d7aa1d66646bc571c1", [:rebar3], [], "hexpm"},
 }

--- a/test/faktory_worker/connection/connection_test.exs
+++ b/test/faktory_worker/connection/connection_test.exs
@@ -37,7 +37,7 @@ defmodule FaktoryWorker.Connection.ConnectionTest do
       expected_hello_command =
         "HELLO {\"pwdhash\":\"b8735599d9a3747a180d8db1e4ca5e3e2079d6eb0c19ab637b4145c9dccb9958\",\"v\":2}\r\n"
 
-      expect(FaktoryWorker.SocketMock, :connect, fn host, port ->
+      expect(FaktoryWorker.SocketMock, :connect, fn host, port, _ ->
         {:ok,
          %FaktoryWorker.Connection{
            host: host,
@@ -67,7 +67,7 @@ defmodule FaktoryWorker.Connection.ConnectionTest do
     test "should return an error if the returned faktory version is not supported" do
       opts = [socket_handler: FaktoryWorker.SocketMock]
 
-      expect(FaktoryWorker.SocketMock, :connect, fn host, port ->
+      expect(FaktoryWorker.SocketMock, :connect, fn host, port, _opts ->
         {:ok,
          %Connection{
            host: host,
@@ -89,7 +89,7 @@ defmodule FaktoryWorker.Connection.ConnectionTest do
     test "should return a socket error" do
       opts = [socket_handler: FaktoryWorker.SocketMock]
 
-      expect(FaktoryWorker.SocketMock, :connect, fn _, _ ->
+      expect(FaktoryWorker.SocketMock, :connect, fn _, _, _ ->
         {:error, :econnrefused}
       end)
 

--- a/test/faktory_worker/connection/integration_test.exs
+++ b/test/faktory_worker/connection/integration_test.exs
@@ -3,7 +3,8 @@ defmodule FaktoryWorker.Connection.IntegrationTest do
 
   alias FaktoryWorker.Connection
 
-  @passworded_credentials Application.get_env(:faktory_worker, :server_passworded)
+  @passworded_connection_opts Application.get_env(:faktory_worker, :passworded_server)
+  @tls_connection_opts Application.get_env(:faktory_worker, :tls_server)
 
   describe "open/1" do
     test "should return a connection to faktory" do
@@ -17,17 +18,31 @@ defmodule FaktoryWorker.Connection.IntegrationTest do
 
     test "should return a connection to a password protected faktory" do
       {:ok, %Connection{} = connection} =
-        Connection.open([password: "very-secret"] ++ @passworded_credentials)
+        Connection.open([password: "very-secret"] ++ @passworded_connection_opts)
 
-      assert connection.host == @passworded_credentials[:host]
-      assert connection.port == @passworded_credentials[:port]
+      assert connection.host == @passworded_connection_opts[:host]
+      assert connection.port == @passworded_connection_opts[:port]
       assert connection.socket_handler == FaktoryWorker.Socket.Tcp
       assert is_port(connection.socket)
     end
 
     test "should return an invalid password error when connection to a password protected faktory" do
-      {:error, reason} = Connection.open([password: "wrong-password"] ++ @passworded_credentials)
+      {:error, reason} =
+        Connection.open([password: "wrong-password"] ++ @passworded_connection_opts)
+
       assert reason == "Invalid password"
+    end
+
+    test "should return a tls connection to faktory" do
+      {:ok, %Connection{} = connection} =
+        Connection.open([use_tls: true, tls_verify: false] ++ @tls_connection_opts)
+
+      assert connection.host == "localhost"
+      assert connection.port == 7519
+      assert connection.socket_handler == FaktoryWorker.Socket.Ssl
+
+      {:sslsocket, {_, socket_port, :tls_connection, _}, _} = connection.socket
+      assert is_port(socket_port)
     end
 
     test "should return error when failing to connect" do

--- a/test/faktory_worker/connection/integration_test.exs
+++ b/test/faktory_worker/connection/integration_test.exs
@@ -37,8 +37,8 @@ defmodule FaktoryWorker.Connection.IntegrationTest do
       {:ok, %Connection{} = connection} =
         Connection.open([use_tls: true, tls_verify: false] ++ @tls_connection_opts)
 
-      assert connection.host == "localhost"
-      assert connection.port == 7519
+      assert connection.host == @tls_connection_opts[:host]
+      assert connection.port == @tls_connection_opts[:port]
       assert connection.socket_handler == FaktoryWorker.Socket.Ssl
 
       {:sslsocket, {_, socket_port, :tls_connection, _}, _} = connection.socket

--- a/test/faktory_worker/connection/socket/ssl_test.exs
+++ b/test/faktory_worker/connection/socket/ssl_test.exs
@@ -1,0 +1,55 @@
+defmodule FaktoryWorker.Connection.Socket.SslTest do
+  use ExUnit.Case, async: true
+
+  alias FaktoryWorker.Connection
+  alias FaktoryWorker.Socket.Ssl
+
+  @tls_host Application.get_env(:faktory_worker, :tls_server)[:host]
+  @tls_port Application.get_env(:faktory_worker, :tls_server)[:port]
+
+  describe "connect/3" do
+    test "should open a ssl socket to faktory" do
+      opts = [tls_verify: false]
+      {:ok, %Connection{} = connection} = Ssl.connect(@tls_host, @tls_port, opts)
+
+      assert connection.host == @tls_host
+      assert connection.port == @tls_port
+      assert connection.socket_handler == Ssl
+
+      {:sslsocket, {_, socket_port, :tls_connection, _}, _} = connection.socket
+      assert is_port(socket_port)
+    end
+
+    test "should return error when failing to connect" do
+      {:error, reason} = Ssl.connect("non-existent-host", @tls_port)
+
+      assert reason == :nxdomain
+    end
+  end
+
+  describe "send/1" do
+    test "should be able to send a packet to faktory" do
+      opts = [tls_verify: false]
+      {:ok, %Connection{} = connection} = Ssl.connect(@tls_host, @tls_port, opts)
+      # need to receive the HELLO response before we can send
+      {:ok, _} = Ssl.recv(connection)
+
+      :ok = Ssl.send(connection, "HELLO {\"v\":2}\r\n")
+
+      # if we have sent the packet correctly we should get an OK response
+      {:ok, response} = Ssl.recv(connection)
+
+      assert response == "+OK\r\n"
+    end
+  end
+
+  describe "recv/1" do
+    test "should be able to receive a packet from faktory" do
+      opts = [tls_verify: false]
+      {:ok, %Connection{} = connection} = Ssl.connect(@tls_host, @tls_port, opts)
+      {:ok, result} = Ssl.recv(connection)
+
+      assert result == "+HI {\"v\":2}\r\n"
+    end
+  end
+end

--- a/test/support/connection_helpers.ex
+++ b/test/support/connection_helpers.ex
@@ -3,7 +3,7 @@ defmodule FaktoryWorker.ConnectionHelpers do
 
   defmacro connection_mox() do
     quote do
-      expect(FaktoryWorker.SocketMock, :connect, fn host, port ->
+      expect(FaktoryWorker.SocketMock, :connect, fn host, port, _opts ->
         {:ok,
          %FaktoryWorker.Connection{
            host: host,


### PR DESCRIPTION
Adds a new `Ssl` module to support connection to faktory over a secure socket.

Currently in draft as Im not happy with the switching logic used to enable/disable certificate verification (https://github.com/SeatedInc/faktory_worker/pull/8/files#diff-2c8b487c9855cb02d4c1751c00e249a8R39). I am looking at changing this to be a passed in config value.

Also I need to find a way to get two faktory servers running at the same time on circle. I believe docker-compose will be the answer here.