### PR TITLE
Add connection pooling and broadway config to allow pushing jobs to faktory

### DIFF
--- a/lib/faktory_worker.ex
+++ b/lib/faktory_worker.ex
@@ -2,4 +2,21 @@ defmodule FaktoryWorker do
   @moduledoc """
   TODO: docs
   """
+
+  @doc false
+  def child_spec(opts \\ []) do
+    name = Keyword.get(opts, :name, __MODULE__)
+    opts = Keyword.put(opts, :name, name)
+
+    children = [
+      {FaktoryWorker.Pool, opts},
+      {FaktoryWorker.PushPipeline, opts}
+    ]
+
+    %{
+      id: name,
+      type: :supervisor,
+      start: {Supervisor, :start_link, [children, [strategy: :one_for_one]]}
+    }
+  end
 end

--- a/lib/faktory_worker.ex
+++ b/lib/faktory_worker.ex
@@ -5,8 +5,7 @@ defmodule FaktoryWorker do
 
   @doc false
   def child_spec(opts \\ []) do
-    name = Keyword.get(opts, :name, __MODULE__)
-    opts = Keyword.put(opts, :name, name)
+    opts = Keyword.put_new(opts, :name, __MODULE__)
 
     children = [
       {FaktoryWorker.Pool, opts},
@@ -14,7 +13,7 @@ defmodule FaktoryWorker do
     ]
 
     %{
-      id: name,
+      id: opts[:name],
       type: :supervisor,
       start: {Supervisor, :start_link, [children, [strategy: :one_for_one]]}
     }

--- a/lib/faktory_worker/connection_manager.ex
+++ b/lib/faktory_worker/connection_manager.ex
@@ -3,13 +3,26 @@ defmodule FaktoryWorker.ConnectionManager do
 
   use GenServer
 
+  alias FaktoryWorker.Connection
+
   def start_link(opts \\ []) do
     GenServer.start_link(__MODULE__, opts)
+  end
+
+  def send_command(connection, command) do
+    GenServer.call(connection, {:send_command, command})
   end
 
   @impl true
   def init(opts) do
     {:ok, connection} = FaktoryWorker.Connection.open(opts)
     {:ok, %{conn: connection}}
+  end
+
+  @impl true
+  def handle_call({:send_command, command}, _, %{conn: connection} = state) do
+    result = Connection.send_command(connection, command)
+
+    {:reply, result, state}
   end
 end

--- a/lib/faktory_worker/connection_manager.ex
+++ b/lib/faktory_worker/connection_manager.ex
@@ -1,0 +1,15 @@
+defmodule FaktoryWorker.ConnectionManager do
+  @moduledoc false
+
+  use GenServer
+
+  def start_link(opts \\ []) do
+    GenServer.start_link(__MODULE__, opts)
+  end
+
+  @impl true
+  def init(opts) do
+    {:ok, connection} = FaktoryWorker.Connection.open(opts)
+    {:ok, %{conn: connection}}
+  end
+end

--- a/lib/faktory_worker/job.ex
+++ b/lib/faktory_worker/job.ex
@@ -21,7 +21,7 @@ defmodule FaktoryWorker.Job do
         opts = Keyword.merge(unquote(using_opts), opts)
 
         __MODULE__
-        |> Job.create_job(job, opts)
+        |> Job.build_payload(job, opts)
         |> Job.perform_async(opts)
       end
     end

--- a/lib/faktory_worker/job.ex
+++ b/lib/faktory_worker/job.ex
@@ -1,0 +1,66 @@
+defmodule FaktoryWorker.Job do
+  @moduledoc """
+  todo: docs
+  """
+
+  defmacro __using__(using_opts \\ []) do
+    alias FaktoryWorker.Job
+
+    quote do
+      def perform_async(job, opts \\ []) do
+        opts = Keyword.merge(unquote(using_opts), opts)
+        Job.perform_async(__MODULE__, job, opts)
+      end
+    end
+  end
+
+  @doc false
+  def perform_async(worker_module, job, opts) when is_list(job) do
+    # maybe use opts to support these optional fields
+    # priority
+    # reserve_for
+    # at
+    # retry
+    # backtrace
+    # created_at
+    # custom
+
+    pipeline_name = push_pipeline_name(opts)
+
+    args = %{
+      jid: random_job_id(),
+      jobtype: job_type_for_module(worker_module),
+      args: job,
+      # support default queues
+      queue: opts[:queue]
+    }
+
+    message = %Broadway.Message{
+      acknowledger: {FaktoryWorker.PushPipeline.Acknowledger, :push_message, []},
+      data: args
+    }
+
+    Broadway.push_messages(pipeline_name, [message])
+  end
+
+  def perform_async(queue, job, opts) do
+    perform_async(queue, [job], opts)
+  end
+
+  defp push_pipeline_name(opts) do
+    opts
+    |> Keyword.get(:faktory_name, FaktoryWorker)
+    |> FaktoryWorker.PushPipeline.format_pipeline_name()
+  end
+
+  defp random_job_id() do
+    rand_bytes = :crypto.strong_rand_bytes(12)
+    Base.encode16(rand_bytes, case: :lower)
+  end
+
+  defp job_type_for_module(module) do
+    module
+    |> to_string()
+    |> String.trim_leading("Elixir.")
+  end
+end

--- a/lib/faktory_worker/pool.ex
+++ b/lib/faktory_worker/pool.ex
@@ -1,0 +1,20 @@
+defmodule FaktoryWorker.Pool do
+  @moduledoc false
+
+  def child_spec(opts) do
+    name = opts[:name]
+    pool_name = :"#{name}_pool"
+    pool_config = Keyword.get(opts, :pool, [])
+
+    :poolboy.child_spec(
+      pool_name,
+      [
+        {:name, {:local, pool_name}},
+        {:worker_module, FaktoryWorker.ConnectionManager},
+        {:size, Keyword.get(pool_config, :size, 10)},
+        {:max_overflow, Keyword.get(pool_config, :size, 10)}
+      ],
+      Keyword.get(opts, :connection, [])
+    )
+  end
+end

--- a/lib/faktory_worker/pool.ex
+++ b/lib/faktory_worker/pool.ex
@@ -3,7 +3,7 @@ defmodule FaktoryWorker.Pool do
 
   def child_spec(opts) do
     name = opts[:name]
-    pool_name = :"#{name}_pool"
+    pool_name = format_pool_name(name)
     pool_config = Keyword.get(opts, :pool, [])
 
     :poolboy.child_spec(
@@ -16,5 +16,10 @@ defmodule FaktoryWorker.Pool do
       ],
       Keyword.get(opts, :connection, [])
     )
+  end
+
+  @spec format_pool_name(name :: atom()) :: atom()
+  def format_pool_name(name) when is_atom(name) do
+    :"#{name}_pool"
   end
 end

--- a/lib/faktory_worker/protocol.ex
+++ b/lib/faktory_worker/protocol.ex
@@ -49,8 +49,11 @@ defmodule FaktoryWorker.Protocol do
 
   defp encode(command, args) do
     case Jason.encode(args) do
-      {:ok, payload} -> {:ok, "#{command} #{payload}\r\n"}
-      error -> error
+      {:ok, payload} ->
+        {:ok, "#{command} #{payload}\r\n"}
+
+      {:error, _} ->
+        {:error, "Invalid command args '#{inspect(args)}' given and could not be encoded"}
     end
   end
 

--- a/lib/faktory_worker/protocol.ex
+++ b/lib/faktory_worker/protocol.ex
@@ -1,11 +1,15 @@
 defmodule FaktoryWorker.Protocol do
   @moduledoc false
 
-  @type protocol_command :: {:hello, map()}
+  @type protocol_command :: {:hello, map()} | {:push, map()}
 
   @spec encode_command(command :: protocol_command()) :: {:ok, String.t()} | {:error, term()}
   def encode_command({:hello, args}) do
     encode("HELLO", args)
+  end
+
+  def encode_command({:push, args}) do
+    encode("PUSH", args)
   end
 
   @spec decode_response(response :: String.t()) :: {:ok, term()} | {:error, term()}

--- a/lib/faktory_worker/protocol.ex
+++ b/lib/faktory_worker/protocol.ex
@@ -1,7 +1,7 @@
 defmodule FaktoryWorker.Protocol do
   @moduledoc false
 
-  @type protocol_command :: {:hello, map()} | {:push, map()}
+  @type protocol_command :: {:hello, map()} | {:push, map()} | :info
 
   @spec encode_command(command :: protocol_command()) :: {:ok, String.t()} | {:error, term()}
   def encode_command({:hello, args}) do
@@ -12,23 +12,51 @@ defmodule FaktoryWorker.Protocol do
     encode("PUSH", args)
   end
 
-  @spec decode_response(response :: String.t()) :: {:ok, term()} | {:error, term()}
+  def encode_command(:info) do
+    encode("INFO")
+  end
+
+  @spec decode_response(response :: String.t()) ::
+          {:ok, term()} | {:ok, {:bulk_string, pos_integer()}} | {:error, term()}
   def decode_response("+HI " <> rest) do
-    rest
-    |> trim_newline()
-    |> Jason.decode()
+    decode(rest)
   end
 
   def decode_response("+OK\r\n"), do: {:ok, "OK"}
 
   def decode_response("-ERR " <> rest), do: {:error, trim_newline(rest)}
 
-  def trim_newline(str), do: String.trim_trailing(str, "\r\n")
+  def decode_response("$" <> rest) do
+    length =
+      rest
+      |> trim_newline()
+      |> String.to_integer()
+
+    # we add '2' to length here to account for the newline '\r\n'
+    # that will be at the end of the next server response
+    {:ok, {:bulk_string, length + 2}}
+  end
+
+  def decode_response("{" <> _ = json_hash) do
+    decode(json_hash)
+  end
+
+  defp trim_newline(str), do: String.trim_trailing(str, "\r\n")
+
+  defp encode(command) do
+    {:ok, "#{command}\r\n"}
+  end
 
   defp encode(command, args) do
     case Jason.encode(args) do
       {:ok, payload} -> {:ok, "#{command} #{payload}\r\n"}
       error -> error
     end
+  end
+
+  defp decode(json_hash) do
+    json_hash
+    |> trim_newline()
+    |> Jason.decode()
   end
 end

--- a/lib/faktory_worker/push_pipeline.ex
+++ b/lib/faktory_worker/push_pipeline.ex
@@ -1,0 +1,40 @@
+defmodule FaktoryWorker.PushPipeline do
+  @moduledoc false
+
+  use Broadway
+
+  alias FaktoryWorker.PushPipeline.Consumer
+
+  # todo: I think we can split this up to make the options built in start_link testable
+
+  def start_link(opts) do
+    pool_config = Keyword.get(opts, :pool, [])
+    pool_size = Keyword.get(pool_config, :size, 10)
+
+    Broadway.start_link(__MODULE__,
+      name: :"#{opts[:name]}_pipeline",
+      producers: [
+        default: [
+          module: {FaktoryWorker.PushPipeline.Producer, []},
+          stages: pool_size
+        ]
+      ],
+      processors: [
+        default: [stages: pool_size]
+      ],
+      batchers: [
+        default: [stages: pool_size, batch_size: 1]
+      ]
+    )
+  end
+
+  @impl true
+  def handle_batch(batcher, messages, batch_info, context) do
+    Consumer.handle_batch(batcher, messages, batch_info, context)
+  end
+
+  @impl true
+  def handle_message(processor_name, message, context) do
+    Consumer.handle_message(processor_name, message, context)
+  end
+end

--- a/lib/faktory_worker/push_pipeline.ex
+++ b/lib/faktory_worker/push_pipeline.ex
@@ -7,12 +7,14 @@ defmodule FaktoryWorker.PushPipeline do
 
   # todo: I think we can split this up to make the options built in start_link testable
 
+  @spec start_link(opts :: keyword()) :: {:ok, pid()} | {:error, any()} | :ignore
   def start_link(opts) do
     pool_config = Keyword.get(opts, :pool, [])
     pool_size = Keyword.get(pool_config, :size, 10)
 
     Broadway.start_link(__MODULE__,
-      name: :"#{opts[:name]}_pipeline",
+      name: format_pipeline_name(opts[:name]),
+      context: %{name: opts[:name]},
       producers: [
         default: [
           module: {FaktoryWorker.PushPipeline.Producer, []},
@@ -36,5 +38,10 @@ defmodule FaktoryWorker.PushPipeline do
   @impl true
   def handle_message(processor_name, message, context) do
     Consumer.handle_message(processor_name, message, context)
+  end
+
+  @spec format_pipeline_name(name :: atom()) :: atom()
+  def format_pipeline_name(name) when is_atom(name) do
+    :"#{name}_pipeline"
   end
 end

--- a/lib/faktory_worker/push_pipeline/acknowledger.ex
+++ b/lib/faktory_worker/push_pipeline/acknowledger.ex
@@ -4,7 +4,7 @@ defmodule FaktoryWorker.PushPipeline.Acknowledger do
   @behaviour Broadway.Acknowledger
 
   @impl true
-  def ack(_ack_ref, successful_messages, failed_messages) do
+  def ack(_ack_ref, _successful_messages, _failed_messages) do
     # need to work out what this should do
     :ok
   end

--- a/lib/faktory_worker/push_pipeline/acknowledger.ex
+++ b/lib/faktory_worker/push_pipeline/acknowledger.ex
@@ -1,0 +1,11 @@
+defmodule FaktoryWorker.PushPipeline.Acknowledger do
+  @moduledoc false
+
+  @behaviour Broadway.Acknowledger
+
+  @impl true
+  def ack(_ack_ref, successful_messages, failed_messages) do
+    # need to work out what this should do
+    :ok
+  end
+end

--- a/lib/faktory_worker/push_pipeline/consumer.ex
+++ b/lib/faktory_worker/push_pipeline/consumer.ex
@@ -1,0 +1,18 @@
+defmodule FaktoryWorker.PushPipeline.Consumer do
+  @moduledoc false
+
+  @behaviour Broadway
+
+  # todo: this is where we will fetch a connection from the pool and push
+  #       jobs to faktory
+
+  @impl true
+  def handle_batch(_, messages, _batch_info, _context) do
+    messages
+  end
+
+  @impl true
+  def handle_message(_processor_name, message, _context) do
+    message
+  end
+end

--- a/lib/faktory_worker/push_pipeline/consumer.ex
+++ b/lib/faktory_worker/push_pipeline/consumer.ex
@@ -1,18 +1,27 @@
 defmodule FaktoryWorker.PushPipeline.Consumer do
   @moduledoc false
 
+  alias FaktoryWorker.{ConnectionManager, Pool}
+
   @behaviour Broadway
 
-  # todo: this is where we will fetch a connection from the pool and push
-  #       jobs to faktory
+  @impl true
+  def handle_message(_processor_name, message, _context), do: message
 
   @impl true
-  def handle_batch(_, messages, _batch_info, _context) do
-    messages
+  def handle_batch(_, [%{data: job} = message], _batch_info, %{name: name}) do
+    result =
+      name
+      |> Pool.format_pool_name()
+      |> :poolboy.transaction(
+        &ConnectionManager.send_command(&1, {:push, job}),
+        5000
+      )
+      |> send_command_result()
+
+    [%{message | status: result}]
   end
 
-  @impl true
-  def handle_message(_processor_name, message, _context) do
-    message
-  end
+  defp send_command_result({:ok, _}), do: :ok
+  defp send_command_result({:error, reason}), do: {:failed, reason}
 end

--- a/lib/faktory_worker/push_pipeline/consumer.ex
+++ b/lib/faktory_worker/push_pipeline/consumer.ex
@@ -5,6 +5,8 @@ defmodule FaktoryWorker.PushPipeline.Consumer do
 
   @behaviour Broadway
 
+  @default_timeout 5000
+
   @impl true
   def handle_message(_processor_name, message, _context), do: message
 
@@ -15,7 +17,7 @@ defmodule FaktoryWorker.PushPipeline.Consumer do
       |> Pool.format_pool_name()
       |> :poolboy.transaction(
         &ConnectionManager.send_command(&1, {:push, job}),
-        5000
+        @default_timeout
       )
       |> send_command_result()
 

--- a/lib/faktory_worker/push_pipeline/producer.ex
+++ b/lib/faktory_worker/push_pipeline/producer.ex
@@ -1,0 +1,15 @@
+defmodule FaktoryWorker.PushPipeline.Producer do
+  @moduledoc false
+
+  use GenStage
+
+  def init(_opts) do
+    {:producer, %{jobs: []}}
+  end
+
+  def handle_demand(demand, %{jobs: jobs} = state) do
+    {dispatch_jobs, remaing_jobs} = Enum.split(jobs, demand)
+
+    {:noreply, dispatch_jobs, %{state | jobs: remaing_jobs}}
+  end
+end

--- a/lib/faktory_worker/socket.ex
+++ b/lib/faktory_worker/socket.ex
@@ -10,4 +10,7 @@ defmodule FaktoryWorker.Socket do
               :ok | {:error, term()}
 
   @callback recv(connection :: Connection.t()) :: {:ok, String.t()} | {:error, term()}
+
+  @callback recv(connection :: Connection.t(), length :: pos_integer()) ::
+              {:ok, String.t()} | {:error, term()}
 end

--- a/lib/faktory_worker/socket/ssl.ex
+++ b/lib/faktory_worker/socket/ssl.ex
@@ -22,6 +22,15 @@ defmodule FaktoryWorker.Socket.Ssl do
     :ssl.recv(socket, 0)
   end
 
+  @impl true
+  def recv(%{socket: socket}, length) do
+    set_packet_mode(socket, :raw)
+    result = :ssl.recv(socket, length)
+    set_packet_mode(socket, :line)
+
+    result
+  end
+
   defp try_connect(host, port, opts) do
     host = String.to_charlist(host)
     tls_verify = Keyword.get(opts, :tls_verify, true)
@@ -40,4 +49,6 @@ defmodule FaktoryWorker.Socket.Ssl do
 
   defp map_tls_verify(true), do: :verify_peer
   defp map_tls_verify(_), do: :verify_none
+
+  defp set_packet_mode(socket, mode), do: :ssl.setopts(socket, packet: mode)
 end

--- a/lib/faktory_worker/socket/tcp.ex
+++ b/lib/faktory_worker/socket/tcp.ex
@@ -22,9 +22,20 @@ defmodule FaktoryWorker.Socket.Tcp do
     :gen_tcp.recv(socket, 0)
   end
 
+  @impl true
+  def recv(%{socket: socket}, length) do
+    set_packet_mode(socket, :raw)
+    result = :gen_tcp.recv(socket, length)
+    set_packet_mode(socket, :line)
+
+    result
+  end
+
   defp try_connect(host, port) do
     host = String.to_charlist(host)
 
     :gen_tcp.connect(host, port, [:binary, active: false, packet: :line])
   end
+
+  defp set_packet_mode(socket, mode), do: :inet.setopts(socket, packet: mode)
 end

--- a/mix.exs
+++ b/mix.exs
@@ -24,9 +24,11 @@ defmodule FaktoryWorker.MixProject do
 
   defp deps do
     [
+      {:broadway, "~> 0.1.0"},
       {:certifi, "~> 2.5"},
       {:excoveralls, "~> 0.10", only: :test},
       {:jason, "~> 1.1"},
+      {:poolboy, "~> 1.5"},
       {:mox, "~> 0.5", only: :test}
     ]
   end

--- a/mix.lock
+++ b/mix.lock
@@ -1,6 +1,8 @@
 %{
+  "broadway": {:hex, :broadway, "0.1.0", "e21ccf0db6175fef890ea51fbd3eb44f171657f8a04e34a1c2b08fdb4a3476b3", [:mix], [{:gen_stage, "~> 0.14", [hex: :gen_stage, repo: "hexpm", optional: false]}], "hexpm"},
   "certifi": {:hex, :certifi, "2.5.1", "867ce347f7c7d78563450a18a6a28a8090331e77fa02380b4a21962a65d36ee5", [:rebar3], [{:parse_trans, "~>3.3", [hex: :parse_trans, repo: "hexpm", optional: false]}], "hexpm"},
   "excoveralls": {:hex, :excoveralls, "0.10.6", "e2b9718c9d8e3ef90bc22278c3f76c850a9f9116faf4ebe9678063310742edc2", [:mix], [{:hackney, "~> 1.13", [hex: :hackney, repo: "hexpm", optional: false]}, {:jason, "~> 1.0", [hex: :jason, repo: "hexpm", optional: false]}], "hexpm"},
+  "gen_stage": {:hex, :gen_stage, "0.14.1", "9d46723fda072d4f4bb31a102560013f7960f5d80ea44dcb96fd6304ed61e7a4", [:mix], [], "hexpm"},
   "hackney": {:hex, :hackney, "1.15.1", "9f8f471c844b8ce395f7b6d8398139e26ddca9ebc171a8b91342ee15a19963f4", [:rebar3], [{:certifi, "2.5.1", [hex: :certifi, repo: "hexpm", optional: false]}, {:idna, "6.0.0", [hex: :idna, repo: "hexpm", optional: false]}, {:metrics, "1.0.1", [hex: :metrics, repo: "hexpm", optional: false]}, {:mimerl, "~>1.1", [hex: :mimerl, repo: "hexpm", optional: false]}, {:ssl_verify_fun, "1.1.4", [hex: :ssl_verify_fun, repo: "hexpm", optional: false]}], "hexpm"},
   "idna": {:hex, :idna, "6.0.0", "689c46cbcdf3524c44d5f3dde8001f364cd7608a99556d8fbd8239a5798d4c10", [:rebar3], [{:unicode_util_compat, "0.4.1", [hex: :unicode_util_compat, repo: "hexpm", optional: false]}], "hexpm"},
   "jason": {:hex, :jason, "1.1.2", "b03dedea67a99223a2eaf9f1264ce37154564de899fd3d8b9a21b1a6fd64afe7", [:mix], [{:decimal, "~> 1.0", [hex: :decimal, repo: "hexpm", optional: true]}], "hexpm"},
@@ -8,6 +10,7 @@
   "mimerl": {:hex, :mimerl, "1.2.0", "67e2d3f571088d5cfd3e550c383094b47159f3eee8ffa08e64106cdf5e981be3", [:rebar3], [], "hexpm"},
   "mox": {:hex, :mox, "0.5.0", "c519b48407017a85f03407a9a4c4ceb7cc6dec5fe886b2241869fb2f08476f9e", [:mix], [], "hexpm"},
   "parse_trans": {:hex, :parse_trans, "3.3.0", "09765507a3c7590a784615cfd421d101aec25098d50b89d7aa1d66646bc571c1", [:rebar3], [], "hexpm"},
+  "poolboy": {:hex, :poolboy, "1.5.2", "392b007a1693a64540cead79830443abf5762f5d30cf50bc95cb2c1aaafa006b", [:rebar3], [], "hexpm"},
   "ssl_verify_fun": {:hex, :ssl_verify_fun, "1.1.4", "f0eafff810d2041e93f915ef59899c923f4568f4585904d010387ed74988e77b", [:make, :mix, :rebar3], [], "hexpm"},
   "unicode_util_compat": {:hex, :unicode_util_compat, "0.4.1", "d869e4c68901dd9531385bb0c8c40444ebf624e60b6962d95952775cac5e90cd", [:rebar3], [], "hexpm"},
 }

--- a/test/faktory_worker/connection/connection_integration_test.exs
+++ b/test/faktory_worker/connection/connection_integration_test.exs
@@ -1,4 +1,4 @@
-defmodule FaktoryWorker.Connection.IntegrationTest do
+defmodule FaktoryWorker.Connection.ConnectionIntegrationTest do
   use ExUnit.Case, async: true
 
   alias FaktoryWorker.Connection

--- a/test/faktory_worker/connection/connection_test.exs
+++ b/test/faktory_worker/connection/connection_test.exs
@@ -115,36 +115,4 @@ defmodule FaktoryWorker.Connection.ConnectionTest do
       assert :called_handler == Connection.send_command(connection, {:hello, %{v: 1}})
     end
   end
-
-  describe "recv/1" do
-    test "should call into the socket handler" do
-      expect(FaktoryWorker.SocketMock, :recv, fn _ ->
-        {:ok, "+OK\r\n"}
-      end)
-
-      connection = %Connection{
-        host: "localhost",
-        port: 1234,
-        socket: :test_socket,
-        socket_handler: FaktoryWorker.SocketMock
-      }
-
-      assert {:ok, "OK"} == Connection.recv(connection)
-    end
-
-    test "should return faktory error" do
-      expect(FaktoryWorker.SocketMock, :recv, fn _ ->
-        {:ok, "-ERR Some error\r\n"}
-      end)
-
-      connection = %Connection{
-        host: "localhost",
-        port: 1234,
-        socket: :test_socket,
-        socket_handler: FaktoryWorker.SocketMock
-      }
-
-      assert {:error, "Some error"} == Connection.recv(connection)
-    end
-  end
 end

--- a/test/faktory_worker/connection/socket/ssl_test.exs
+++ b/test/faktory_worker/connection/socket/ssl_test.exs
@@ -52,4 +52,14 @@ defmodule FaktoryWorker.Connection.Socket.SslTest do
       assert result == "+HI {\"v\":2}\r\n"
     end
   end
+
+  describe "recv/2" do
+    test "should be able to receive a raw packet from faktory" do
+      opts = [tls_verify: false]
+      {:ok, %Connection{} = connection} = Ssl.connect(@tls_host, @tls_port, opts)
+      {:ok, result} = Ssl.recv(connection, 13)
+
+      assert result == "+HI {\"v\":2}\r\n"
+    end
+  end
 end

--- a/test/faktory_worker/connection/socket/tcp_test.exs
+++ b/test/faktory_worker/connection/socket/tcp_test.exs
@@ -44,4 +44,13 @@ defmodule FaktoryWorker.Connection.Socket.TcpTest do
       assert result == "+HI {\"v\":2}\r\n"
     end
   end
+
+  describe "recv/2" do
+    test "should be able to receive a raw packet from faktory" do
+      {:ok, %Connection{} = connection} = Tcp.connect("localhost", 7419)
+      {:ok, result} = Tcp.recv(connection, 13)
+
+      assert result == "+HI {\"v\":2}\r\n"
+    end
+  end
 end

--- a/test/faktory_worker/job/job_integration_test.exs
+++ b/test/faktory_worker/job/job_integration_test.exs
@@ -1,0 +1,40 @@
+defmodule FaktoryWorker.JobIntegrationTest do
+  use ExUnit.Case
+
+  alias FaktoryWorker.Job
+
+  describe "perform_async/3" do
+    test "should send a new job to faktory" do
+      faktory_name = :"Test_#{random_string()}"
+      start_supervised!({FaktoryWorker, name: faktory_name, pool: [size: 1]})
+
+      queue_name = random_string()
+
+      opts = [
+        queue: queue_name,
+        faktory_name: faktory_name
+      ]
+
+      job = Job.build_payload(SomeWorker, %{hey: "there!"}, opts)
+
+      Job.perform_async(job, opts)
+
+      assert_queue_size(queue_name, 1)
+
+      :ok = stop_supervised(faktory_name)
+    end
+  end
+
+  defp assert_queue_size(queue_name, expected_size) do
+    Process.sleep(20)
+    {:ok, connection} = FaktoryWorker.Connection.open()
+    {:ok, info} = FaktoryWorker.Connection.send_command(connection, :info)
+
+    assert get_in(info, ["faktory", "queues", queue_name]) == expected_size
+  end
+
+  defp random_string() do
+    bytes = :crypto.strong_rand_bytes(12)
+    Base.encode16(bytes)
+  end
+end

--- a/test/faktory_worker/job/job_test.exs
+++ b/test/faktory_worker/job/job_test.exs
@@ -1,0 +1,48 @@
+defmodule FaktoryWorker.Job.JobTest do
+  use ExUnit.Case, async: true
+
+  alias FaktoryWorker.Job
+
+  describe "build_payload/3" do
+    test "should create new faktory job struct" do
+      data = %{hey: "there!"}
+      job = Job.build_payload(Test.Worker, [data], [])
+
+      assert job.jid != nil
+      assert job.jobtype == "Test.Worker"
+      assert job.args == [data]
+    end
+
+    test "should be able to pass in multiple job args" do
+      data = %{hey: "there!"}
+      job = Job.build_payload(Test.Worker, ["some_text", data, 123], [])
+
+      assert job.jid != nil
+      assert job.jobtype == "Test.Worker"
+      assert job.args == ["some_text", data, 123]
+    end
+
+    test "should be able to pass in a non list job arg" do
+      data = %{hey: "there!"}
+      job = Job.build_payload(Test.Worker, data, [])
+
+      assert job.jid != nil
+      assert job.jobtype == "Test.Worker"
+      assert job.args == [data]
+    end
+
+    test "should be able to specify a queue name" do
+      data = %{hey: "there!"}
+      opts = [queue: "test_queue"]
+      job = Job.build_payload(Test.Worker, data, opts)
+
+      assert job.queue == "test_queue"
+    end
+
+    test "should set the job id to a long string" do
+      job = Job.build_payload(Test.Worker, 123, [])
+
+      assert byte_size(job.jid) == 24
+    end
+  end
+end

--- a/test/faktory_worker/pool_test.exs
+++ b/test/faktory_worker/pool_test.exs
@@ -1,0 +1,63 @@
+defmodule FaktoryWorker.PoolTest do
+  use ExUnit.Case
+
+  describe "child_spec/1" do
+    test "should return a default child_spec" do
+      opts = [name: FaktoryWorker]
+      child_spec = FaktoryWorker.Pool.child_spec(opts)
+
+      assert child_spec == default_child_spec()
+    end
+
+    test "should allow a custom name to be specified" do
+      opts = [
+        name: :my_test_faktory
+      ]
+
+      child_spec = FaktoryWorker.Pool.child_spec(opts)
+      config = get_child_spec_config(child_spec)
+
+      assert config[:name] == {:local, :my_test_faktory_pool}
+    end
+
+    test "should allow pool config to be specified" do
+      opts = [
+        name: FaktoryWorker,
+        pool: [
+          size: 25
+        ]
+      ]
+
+      child_spec = FaktoryWorker.Pool.child_spec(opts)
+      config = get_child_spec_config(child_spec)
+
+      assert config[:size] == 25
+      assert config[:max_overflow] == 25
+    end
+  end
+
+  defp default_child_spec() do
+    {FaktoryWorker_pool,
+     {:poolboy, :start_link,
+      [
+        [
+          name: {:local, FaktoryWorker_pool},
+          worker_module: FaktoryWorker.ConnectionManager,
+          size: 10,
+          max_overflow: 10
+        ],
+        []
+      ]}, :permanent, 5000, :worker, [:poolboy]}
+  end
+
+  defp get_child_spec_config(child_spec) do
+    {_,
+     {:poolboy, :start_link,
+      [
+        config,
+        []
+      ]}, :permanent, 5000, :worker, [:poolboy]} = child_spec
+
+    config
+  end
+end

--- a/test/faktory_worker/pool_test.exs
+++ b/test/faktory_worker/pool_test.exs
@@ -1,10 +1,12 @@
 defmodule FaktoryWorker.PoolTest do
   use ExUnit.Case
 
+  alias FaktoryWorker.Pool
+
   describe "child_spec/1" do
     test "should return a default child_spec" do
       opts = [name: FaktoryWorker]
-      child_spec = FaktoryWorker.Pool.child_spec(opts)
+      child_spec = Pool.child_spec(opts)
 
       assert child_spec == default_child_spec()
     end
@@ -14,7 +16,7 @@ defmodule FaktoryWorker.PoolTest do
         name: :my_test_faktory
       ]
 
-      child_spec = FaktoryWorker.Pool.child_spec(opts)
+      child_spec = Pool.child_spec(opts)
       config = get_child_spec_config(child_spec)
 
       assert config[:name] == {:local, :my_test_faktory_pool}
@@ -28,11 +30,17 @@ defmodule FaktoryWorker.PoolTest do
         ]
       ]
 
-      child_spec = FaktoryWorker.Pool.child_spec(opts)
+      child_spec = Pool.child_spec(opts)
       config = get_child_spec_config(child_spec)
 
       assert config[:size] == 25
       assert config[:max_overflow] == 25
+    end
+  end
+
+  describe "format_pool_name/1" do
+    test "should append a suffix to the given name" do
+      assert :my_test_pool == Pool.format_pool_name(:my_test)
     end
   end
 

--- a/test/faktory_worker/protocol_test.exs
+++ b/test/faktory_worker/protocol_test.exs
@@ -26,6 +26,12 @@ defmodule FaktoryWorker.ProtocolTest do
 
       assert command == "INFO\r\n"
     end
+
+    test "should return an error when attempting to encode bad data" do
+      {:error, reason} = Protocol.encode_command({:hello, {:v, 2}})
+
+      assert reason == "Invalid command args '{:v, 2}' given and could not be encoded"
+    end
   end
 
   describe "decode_response/1" do

--- a/test/faktory_worker/protocol_test.exs
+++ b/test/faktory_worker/protocol_test.exs
@@ -20,6 +20,12 @@ defmodule FaktoryWorker.ProtocolTest do
       assert command ==
                "PUSH {\"args\":[{\"some\":\"values\"}],\"jid\":\"123456\",\"jobtype\":\"TestJob\",\"queue\":\"test_queue\"}\r\n"
     end
+
+    test "should encode the 'INFO' command" do
+      {:ok, command} = Protocol.encode_command(:info)
+
+      assert command == "INFO\r\n"
+    end
   end
 
   describe "decode_response/1" do
@@ -39,6 +45,21 @@ defmodule FaktoryWorker.ProtocolTest do
       {:error, resposne} = Protocol.decode_response("-ERR Some error\r\n")
 
       assert resposne == "Some error"
+    end
+
+    test "should decode the '$n' bulk string response" do
+      {:ok, resposne} = Protocol.decode_response("$592\r\n")
+
+      assert resposne == {:bulk_string, 594}
+    end
+
+    test "should decode bulk string response" do
+      {:ok, response} = Protocol.decode_response("{\"some\":\"longer\",\"response\":\"data\"}")
+
+      assert response == %{
+               "response" => "data",
+               "some" => "longer"
+             }
     end
   end
 end

--- a/test/faktory_worker/protocol_test.exs
+++ b/test/faktory_worker/protocol_test.exs
@@ -9,6 +9,17 @@ defmodule FaktoryWorker.ProtocolTest do
 
       assert command == "HELLO {\"v\":2}\r\n"
     end
+
+    test "should encode the 'PUSH' command" do
+      {:ok, command} =
+        Protocol.encode_command(
+          {:push,
+           %{jid: "123456", jobtype: "TestJob", queue: "test_queue", args: [%{some: "values"}]}}
+        )
+
+      assert command ==
+               "PUSH {\"args\":[{\"some\":\"values\"}],\"jid\":\"123456\",\"jobtype\":\"TestJob\",\"queue\":\"test_queue\"}\r\n"
+    end
   end
 
   describe "decode_response/1" do

--- a/test/faktory_worker/push_pipeline_test.exs
+++ b/test/faktory_worker/push_pipeline_test.exs
@@ -1,0 +1,66 @@
+defmodule FaktoryWorker.PushPipelineTest do
+  use ExUnit.Case
+
+  describe "child_spec/1" do
+    test "should return a default child_spec" do
+      opts = [name: FaktoryWorker]
+      child_spec = FaktoryWorker.PushPipeline.child_spec(opts)
+
+      assert child_spec == default_child_spec()
+    end
+
+    test "should allow a custom name to be specified" do
+      opts = [
+        name: :my_test_faktory
+      ]
+
+      child_spec = FaktoryWorker.PushPipeline.child_spec(opts)
+      config = get_child_spec_config(child_spec)
+
+      assert config[:name] == :my_test_faktory
+    end
+
+    test "should allow pool config to be specified" do
+      opts = [
+        name: FaktoryWorker,
+        pool: [
+          size: 25
+        ]
+      ]
+
+      child_spec = FaktoryWorker.PushPipeline.child_spec(opts)
+      config = get_child_spec_config(child_spec)
+
+      assert config[:pool][:size] == 25
+    end
+  end
+
+  describe "start_link/1" do
+    test "should start the pipeline" do
+      opts = [name: FaktoryWorker]
+      pid = start_supervised!(FaktoryWorker.PushPipeline.child_spec(opts))
+
+      assert pid == Process.whereis(FaktoryWorker_pipeline)
+
+      :ok = stop_supervised(FaktoryWorker.PushPipeline)
+    end
+  end
+
+  defp default_child_spec() do
+    %{
+      id: FaktoryWorker.PushPipeline,
+      start: {FaktoryWorker.PushPipeline, :start_link, [[name: FaktoryWorker]]},
+      type: :supervisor
+    }
+  end
+
+  defp get_child_spec_config(child_spec) do
+    %{
+      id: FaktoryWorker.PushPipeline,
+      start: {FaktoryWorker.PushPipeline, :start_link, [config]},
+      type: :supervisor
+    } = child_spec
+
+    config
+  end
+end

--- a/test/faktory_worker/push_pipeline_test.exs
+++ b/test/faktory_worker/push_pipeline_test.exs
@@ -1,10 +1,12 @@
 defmodule FaktoryWorker.PushPipelineTest do
   use ExUnit.Case
 
+  alias FaktoryWorker.PushPipeline
+
   describe "child_spec/1" do
     test "should return a default child_spec" do
       opts = [name: FaktoryWorker]
-      child_spec = FaktoryWorker.PushPipeline.child_spec(opts)
+      child_spec = PushPipeline.child_spec(opts)
 
       assert child_spec == default_child_spec()
     end
@@ -14,7 +16,7 @@ defmodule FaktoryWorker.PushPipelineTest do
         name: :my_test_faktory
       ]
 
-      child_spec = FaktoryWorker.PushPipeline.child_spec(opts)
+      child_spec = PushPipeline.child_spec(opts)
       config = get_child_spec_config(child_spec)
 
       assert config[:name] == :my_test_faktory
@@ -28,7 +30,7 @@ defmodule FaktoryWorker.PushPipelineTest do
         ]
       ]
 
-      child_spec = FaktoryWorker.PushPipeline.child_spec(opts)
+      child_spec = PushPipeline.child_spec(opts)
       config = get_child_spec_config(child_spec)
 
       assert config[:pool][:size] == 25
@@ -43,6 +45,12 @@ defmodule FaktoryWorker.PushPipelineTest do
       assert pid == Process.whereis(FaktoryWorker_pipeline)
 
       :ok = stop_supervised(FaktoryWorker.PushPipeline)
+    end
+  end
+
+  describe "format_pipeline_name/1" do
+    test "should append a suffix to the given name" do
+      assert :my_test_pipeline == PushPipeline.format_pipeline_name(:my_test)
     end
   end
 

--- a/test/faktory_worker_test.exs
+++ b/test/faktory_worker_test.exs
@@ -1,3 +1,88 @@
 defmodule FaktoryWorkerTest do
   use ExUnit.Case
+
+  describe "child_spec/0" do
+    test "should return a default child_spec" do
+      child_spec = FaktoryWorker.child_spec()
+
+      assert child_spec == default_child_spec()
+    end
+  end
+
+  describe "child_spec/1" do
+    test "should allow a name to be specified" do
+      opts = [
+        name: :my_test_faktory
+      ]
+
+      child_spec = FaktoryWorker.child_spec(opts)
+      config = get_child_spec_config(child_spec)
+
+      assert config == [
+               {FaktoryWorker.Pool, [name: :my_test_faktory]},
+               {FaktoryWorker.PushPipeline, [name: :my_test_faktory]}
+             ]
+    end
+
+    test "should allow pool config to be specified" do
+      opts = [
+        pool: [
+          size: 25
+        ]
+      ]
+
+      child_spec = FaktoryWorker.child_spec(opts)
+      config = get_child_spec_config(child_spec)
+
+      assert config == [
+               {FaktoryWorker.Pool, [name: FaktoryWorker, pool: [size: 25]]},
+               {FaktoryWorker.PushPipeline, [name: FaktoryWorker, pool: [size: 25]]}
+             ]
+    end
+
+    test "should allow connection configuration to be specified" do
+      opts = [
+        connection: [
+          host: "somehost",
+          port: 7519
+        ]
+      ]
+
+      child_spec = FaktoryWorker.child_spec(opts)
+      config = get_child_spec_config(child_spec)
+
+      assert config == [
+               {FaktoryWorker.Pool,
+                [name: FaktoryWorker, connection: [host: "somehost", port: 7519]]},
+               {FaktoryWorker.PushPipeline,
+                [name: FaktoryWorker, connection: [host: "somehost", port: 7519]]}
+             ]
+    end
+  end
+
+  defp default_child_spec() do
+    %{
+      id: FaktoryWorker,
+      start:
+        {Supervisor, :start_link,
+         [
+           [
+             {FaktoryWorker.Pool, [name: FaktoryWorker]},
+             {FaktoryWorker.PushPipeline, [name: FaktoryWorker]}
+           ],
+           [strategy: :one_for_one]
+         ]},
+      type: :supervisor
+    }
+  end
+
+  defp get_child_spec_config(%{start: start_config}) do
+    {Supervisor, :start_link,
+     [
+       config,
+       [strategy: :one_for_one]
+     ]} = start_config
+
+    config
+  end
 end


### PR DESCRIPTION
This PR adds connection pooling support and a broadway pipeline to support pushing jobs into faktory. 

~This is currently a WIP because I still need to add the `Job` module which will be used by clients to push messages and to implement the push protocol command.~