### PR TITLE
Handle reconnecting when there is a socket level failure

### DIFF
--- a/lib/faktory_worker/connection_manager.ex
+++ b/lib/faktory_worker/connection_manager.ex
@@ -1,28 +1,58 @@
 defmodule FaktoryWorker.ConnectionManager do
   @moduledoc false
 
-  use GenServer
-
   alias FaktoryWorker.Connection
+  alias FaktoryWorker.ConnectionManager
 
-  def start_link(opts \\ []) do
-    GenServer.start_link(__MODULE__, opts)
+  @connection_errors [
+    :closed,
+    :enotconn,
+    :econnrefused
+  ]
+
+  defstruct [:opts, :conn]
+
+  def new(opts) do
+    %__MODULE__{
+      conn: open_connection(opts),
+      opts: opts
+    }
   end
 
-  def send_command(connection, command) do
-    GenServer.call(connection, {:send_command, command})
+  def send_command(%ConnectionManager{} = state, command) do
+    case try_send_command(state, command) do
+      {{:error, reason}, _} when reason in @connection_errors ->
+        error = {:error, "Failed to connect to Faktory"}
+        state = %{state | conn: nil}
+
+        {error, state}
+
+      {result, state} ->
+        {result, state}
+    end
   end
 
-  @impl true
-  def init(opts) do
-    {:ok, connection} = FaktoryWorker.Connection.open(opts)
-    {:ok, %{conn: connection}}
+  defp try_send_command(%{conn: nil, opts: opts} = state, command) do
+    case open_connection(opts) do
+      nil ->
+        {{:error, "Failed to connect to Faktory"}, state}
+
+      connection ->
+        state = %{state | conn: connection}
+
+        try_send_command(state, command)
+    end
   end
 
-  @impl true
-  def handle_call({:send_command, command}, _, %{conn: connection} = state) do
+  defp try_send_command(%{conn: connection} = state, command) do
     result = Connection.send_command(connection, command)
+    {result, state}
+  end
 
-    {:reply, result, state}
+  defp open_connection(opts) do
+    case Connection.open(opts) do
+      {:ok, connection} -> connection
+      _ -> nil
+    end
   end
 end

--- a/lib/faktory_worker/connection_manager.ex
+++ b/lib/faktory_worker/connection_manager.ex
@@ -19,13 +19,15 @@ defmodule FaktoryWorker.ConnectionManager do
     }
   end
 
-  def send_command(%ConnectionManager{} = state, command) do
+  def send_command(%ConnectionManager{} = state, command, allow_retry \\ true) do
     case try_send_command(state, command) do
       {{:error, reason}, _} when reason in @connection_errors ->
         error = {:error, "Failed to connect to Faktory"}
         state = %{state | conn: nil}
 
-        {error, state}
+        if allow_retry,
+          do: send_command(%{state | conn: nil}, command, false),
+          else: {error, state}
 
       {result, state} ->
         {result, state}

--- a/lib/faktory_worker/connection_manager/server.ex
+++ b/lib/faktory_worker/connection_manager/server.ex
@@ -1,0 +1,29 @@
+defmodule FaktoryWorker.ConnectionManager.Server do
+  @moduledoc false
+
+  use GenServer
+
+  alias FaktoryWorker.ConnectionManager
+
+  @spec start_link(opts :: keyword()) :: {:ok, pid()} | :ignore | {:error, any()}
+  def start_link(opts \\ []) do
+    GenServer.start_link(__MODULE__, opts)
+  end
+
+  @spec send_command(connection_manager :: atom() | pid(), command :: Protocol.protocol_command()) ::
+          {:ok, any()} | {:error, any()}
+  def send_command(connection_manager, command) do
+    GenServer.call(connection_manager, {:send_command, command})
+  end
+
+  @impl true
+  def init(opts) do
+    {:ok, ConnectionManager.new(opts)}
+  end
+
+  @impl true
+  def handle_call({:send_command, command}, _, state) do
+    {result, state} = ConnectionManager.send_command(state, command)
+    {:reply, result, state}
+  end
+end

--- a/lib/faktory_worker/pool.ex
+++ b/lib/faktory_worker/pool.ex
@@ -10,7 +10,7 @@ defmodule FaktoryWorker.Pool do
       pool_name,
       [
         {:name, {:local, pool_name}},
-        {:worker_module, FaktoryWorker.ConnectionManager},
+        {:worker_module, FaktoryWorker.ConnectionManager.Server},
         {:size, Keyword.get(pool_config, :size, 10)},
         {:max_overflow, Keyword.get(pool_config, :size, 10)}
       ],

--- a/lib/faktory_worker/push_pipeline/consumer.ex
+++ b/lib/faktory_worker/push_pipeline/consumer.ex
@@ -16,7 +16,7 @@ defmodule FaktoryWorker.PushPipeline.Consumer do
       name
       |> Pool.format_pool_name()
       |> :poolboy.transaction(
-        &ConnectionManager.send_command(&1, {:push, job}),
+        &ConnectionManager.Server.send_command(&1, {:push, job}),
         @default_timeout
       )
       |> send_command_result()

--- a/test/faktory_worker/connection_manager_test.exs
+++ b/test/faktory_worker/connection_manager_test.exs
@@ -1,0 +1,120 @@
+defmodule FaktoryWorker.ConnectionManagerTest do
+  use ExUnit.Case
+
+  import Mox
+  import FaktoryWorker.ConnectionHelpers
+
+  alias FaktoryWorker.Connection
+  alias FaktoryWorker.ConnectionManager
+
+  setup :verify_on_exit!
+
+  describe "new/1" do
+    test "should return a new connection manager struct" do
+      connection_mox()
+
+      opts = [socket_handler: FaktoryWorker.SocketMock]
+
+      %ConnectionManager{opts: connection_opts, conn: connection} = ConnectionManager.new(opts)
+
+      assert connection_opts == opts
+
+      assert connection == %Connection{
+               host: "localhost",
+               port: 7419,
+               socket: :test_socket,
+               socket_handler: FaktoryWorker.SocketMock
+             }
+    end
+
+    test "should return a new connection manager with nil connection when socket failed to connect" do
+      expect(FaktoryWorker.SocketMock, :connect, fn _, _, _ ->
+        {:error, :econnrefused}
+      end)
+
+      opts = [socket_handler: FaktoryWorker.SocketMock]
+
+      %ConnectionManager{opts: connection_opts, conn: connection} = ConnectionManager.new(opts)
+
+      assert connection_opts == opts
+      assert connection == nil
+    end
+  end
+
+  describe "send_command/2" do
+    test "should be able to send a command" do
+      connection_mox()
+
+      expect(FaktoryWorker.SocketMock, :send, fn _, "INFO\r\n" ->
+        :ok
+      end)
+
+      expect(FaktoryWorker.SocketMock, :recv, fn _ ->
+        {:ok, "+OK\r\n"}
+      end)
+
+      opts = [socket_handler: FaktoryWorker.SocketMock]
+      state = ConnectionManager.new(opts)
+
+      {{:ok, result}, _} = ConnectionManager.send_command(state, :info)
+
+      assert result == "OK"
+    end
+
+    test "should unset the connection when there is a socket failure" do
+      connection_mox()
+
+      expect(FaktoryWorker.SocketMock, :send, fn _, "INFO\r\n" ->
+        {:error, :closed}
+      end)
+
+      opts = [socket_handler: FaktoryWorker.SocketMock]
+      state = ConnectionManager.new(opts)
+
+      {{:error, error}, state} = ConnectionManager.send_command(state, :info)
+
+      assert error == "Failed to connect to Faktory"
+      assert state.conn == nil
+    end
+
+    test "should open a new connection when no connection exists" do
+      connection_mox()
+
+      expect(FaktoryWorker.SocketMock, :send, fn _, "INFO\r\n" ->
+        :ok
+      end)
+
+      expect(FaktoryWorker.SocketMock, :recv, fn _ ->
+        {:ok, "+OK\r\n"}
+      end)
+
+      opts = [socket_handler: FaktoryWorker.SocketMock]
+      state = %ConnectionManager{opts: opts, conn: nil}
+
+      {{:ok, result}, state} = ConnectionManager.send_command(state, :info)
+
+      assert result == "OK"
+
+      assert state.conn == %Connection{
+               host: "localhost",
+               port: 7419,
+               socket: :test_socket,
+               socket_handler: FaktoryWorker.SocketMock
+             }
+    end
+
+    test "should return an error if the connection still can't be opened" do
+      expect(FaktoryWorker.SocketMock, :connect, fn _, _, _ ->
+        {:error, :econnrefused}
+      end)
+
+      opts = [socket_handler: FaktoryWorker.SocketMock]
+      state = %ConnectionManager{opts: opts, conn: nil}
+
+      {{:error, error}, state} = ConnectionManager.send_command(state, :info)
+
+      assert error == "Failed to connect to Faktory"
+      assert state.conn == nil
+    end
+  end
+end

--- a/test/faktory_worker/pool_test.exs
+++ b/test/faktory_worker/pool_test.exs
@@ -50,7 +50,7 @@ defmodule FaktoryWorker.PoolTest do
       [
         [
           name: {:local, FaktoryWorker_pool},
-          worker_module: FaktoryWorker.ConnectionManager,
+          worker_module: FaktoryWorker.ConnectionManager.Server,
           size: 10,
           max_overflow: 10
         ],


### PR DESCRIPTION
Updates the connection manager to attempt to reconnect the socket when the previous message failed. The reconnection will happen when the next request comes into the connection manager, this way we don't continually attempt to reconnect all failed connections at once.

Fixes #13 

~Currently in draft since I am struggling to test this behaviour with unit tests. I have manually tested this to confirm it is working as expected.~