### PR TITLE
Support custom job field and data type validation

### DIFF
--- a/test/faktory_worker/job/job_test.exs
+++ b/test/faktory_worker/job/job_test.exs
@@ -39,10 +39,58 @@ defmodule FaktoryWorker.Job.JobTest do
       assert job.queue == "test_queue"
     end
 
+    test "should not be able to specify an invalid data type for queue name" do
+      data = %{hey: "there!"}
+      opts = [queue: 123]
+      job = Job.build_payload(Test.Worker, data, opts)
+
+      assert job == {:error, "The field 'queue' has an invalid value '123'"}
+    end
+
+    test "should be able to specify a custom map of values" do
+      data = %{hey: "there!"}
+      opts = [custom: %{unique_for: 120}]
+      job = Job.build_payload(Test.Worker, data, opts)
+
+      assert job.custom == %{unique_for: 120}
+    end
+
+    test "should not be able to specify an invalid data type for custom data" do
+      data = %{hey: "there!"}
+      opts = [custom: [1, 2, 3]]
+      job = Job.build_payload(Test.Worker, data, opts)
+
+      assert job == {:error, "The field 'custom' has an invalid value '[1, 2, 3]'"}
+    end
+
     test "should set the job id to a long string" do
       job = Job.build_payload(Test.Worker, 123, [])
 
       assert byte_size(job.jid) == 24
+    end
+  end
+
+  describe "perform_async/2" do
+    test "should not send a bad payload" do
+      data = %{hey: "there!"}
+      opts = [queue: 123]
+      {:error, _} = payload = Job.build_payload(Test.Worker, data, opts)
+
+      {:error, error} = Job.perform_async(payload, [])
+
+      assert error == "The field 'queue' has an invalid value '123'"
+    end
+  end
+
+  describe "perform_async/3" do
+    test "should not send a bad payload" do
+      data = %{hey: "there!"}
+      opts = [queue: 123]
+      {:error, _} = payload = Job.build_payload(Test.Worker, data, opts)
+
+      {:error, error} = Job.perform_async(TestPipeline, payload, [])
+
+      assert error == "The field 'queue' has an invalid value '123'"
     end
   end
 end


### PR DESCRIPTION
Updates the job module to support the `:custom` job field and adds validation to the values specified for supported optional fields.