### PR TITLE
Add support for creating worker connections

### DIFF
--- a/lib/faktory_worker/connection.ex
+++ b/lib/faktory_worker/connection.ex
@@ -4,6 +4,7 @@ defmodule FaktoryWorker.Connection do
   alias FaktoryWorker.Connection
   alias FaktoryWorker.Socket.{Tcp, Ssl}
   alias FaktoryWorker.Protocol
+  alias FaktoryWorker.Random
 
   @faktory_version 2
 
@@ -74,10 +75,12 @@ defmodule FaktoryWorker.Connection do
 
   defp send_handshake({:ok, response}, connection, opts) do
     password = Keyword.get(opts, :password)
+    is_worker = Keyword.get(opts, :is_worker, false)
 
     args =
       %{v: @faktory_version}
       |> append_password_hash(response, password)
+      |> append_worker_fields(is_worker)
 
     send_command(connection, {:hello, args})
   end
@@ -96,6 +99,22 @@ defmodule FaktoryWorker.Connection do
   end
 
   defp append_password_hash(args, _, _), do: args
+
+  defp append_worker_fields(args, true) do
+    {:ok, hostname} = :inet.gethostname()
+    sys_pid = System.get_pid()
+
+    worker_args = %{
+      hostname: to_string(hostname),
+      wid: Random.worker_id(),
+      pid: String.to_integer(sys_pid),
+      labels: ["elixir-#{System.version()}"]
+    }
+
+    Map.merge(args, worker_args)
+  end
+
+  defp append_worker_fields(args, _), do: args
 
   defp default_socket_handler(true), do: Ssl
   defp default_socket_handler(_), do: Tcp

--- a/lib/faktory_worker/job.ex
+++ b/lib/faktory_worker/job.ex
@@ -3,6 +3,8 @@ defmodule FaktoryWorker.Job do
   todo: docs
   """
 
+  alias FaktoryWorker.Random
+
   # Look at supporting the following optional fields when pushing a job
   # priority
   # reserve_for
@@ -30,7 +32,7 @@ defmodule FaktoryWorker.Job do
   @doc false
   def build_payload(worker_module, job, opts) when is_list(job) do
     %{
-      jid: random_job_id(),
+      jid: Random.job_id(),
       jobtype: job_type_for_module(worker_module),
       args: job
     }
@@ -71,11 +73,6 @@ defmodule FaktoryWorker.Job do
     opts
     |> Keyword.get(:faktory_name, FaktoryWorker)
     |> FaktoryWorker.PushPipeline.format_pipeline_name()
-  end
-
-  defp random_job_id() do
-    rand_bytes = :crypto.strong_rand_bytes(12)
-    Base.encode16(rand_bytes, case: :lower)
   end
 
   defp job_type_for_module(module) do

--- a/lib/faktory_worker/random.ex
+++ b/lib/faktory_worker/random.ex
@@ -1,0 +1,21 @@
+defmodule FaktoryWorker.Random do
+  @moduledoc false
+
+  def job_id() do
+    random_hex(12)
+  end
+
+  def worker_id() do
+    random_hex(8)
+  end
+
+  def string() do
+    random_hex(16)
+  end
+
+  defp random_hex(byte_length) do
+    byte_length
+    |> :crypto.strong_rand_bytes()
+    |> Base.encode16(case: :lower)
+  end
+end

--- a/test/faktory_worker/connection/connection_integration_test.exs
+++ b/test/faktory_worker/connection/connection_integration_test.exs
@@ -33,6 +33,12 @@ defmodule FaktoryWorker.Connection.ConnectionIntegrationTest do
       assert reason == "Invalid password"
     end
 
+    test "should return an invalid password error if a password has not been set" do
+      {:error, reason} = Connection.open([] ++ @passworded_connection_opts)
+
+      assert reason == "Invalid password"
+    end
+
     test "should return a tls connection to faktory" do
       {:ok, %Connection{} = connection} =
         Connection.open([use_tls: true, tls_verify: false] ++ @tls_connection_opts)

--- a/test/faktory_worker/job/job_integration_test.exs
+++ b/test/faktory_worker/job/job_integration_test.exs
@@ -4,13 +4,14 @@ defmodule FaktoryWorker.JobIntegrationTest do
   import FaktoryWorker.FaktoryTestHelpers
 
   alias FaktoryWorker.Job
+  alias FaktoryWorker.Random
 
   describe "perform_async/3" do
     test "should send a new job to faktory" do
-      faktory_name = :"Test_#{random_string()}"
+      faktory_name = :"Test_#{Random.string()}"
       start_supervised!({FaktoryWorker, name: faktory_name, pool: [size: 1]})
 
-      queue_name = random_string()
+      queue_name = Random.string()
 
       opts = [
         queue: queue_name,

--- a/test/faktory_worker/push_pipeline/acknowledger_integration_test.exs
+++ b/test/faktory_worker/push_pipeline/acknowledger_integration_test.exs
@@ -5,11 +5,12 @@ defmodule FaktoryWorker.PushPipeline.AcknowledgerIntegrationTest do
 
   alias FaktoryWorker.Job
   alias FaktoryWorker.PushPipeline.Acknowledger
+  alias FaktoryWorker.Random
 
   describe "ack/3" do
     test "should requeue a failed jobs" do
-      faktory_name = :"Test_#{random_string()}"
-      queue_name = random_string()
+      faktory_name = :"Test_#{Random.string()}"
+      queue_name = Random.string()
       pipeline_name = FaktoryWorker.PushPipeline.format_pipeline_name(faktory_name)
 
       job = %{hey: "there!"}

--- a/test/faktory_worker/random_test.exs
+++ b/test/faktory_worker/random_test.exs
@@ -1,0 +1,60 @@
+defmodule FaktoryWorker.RandomTest do
+  use ExUnit.Case
+
+  alias FaktoryWorker.Random
+
+  describe "job_id/0" do
+    test "should return a random hex" do
+      hex1 = Random.job_id()
+      hex2 = Random.job_id()
+
+      assert hex1 != hex2
+    end
+
+    test "should return a lower case hex" do
+      hex = Random.job_id()
+
+      assert hex == String.downcase(hex)
+    end
+
+    test "should return a random hex based on 12 random bytes" do
+      hex = Random.job_id()
+      decoded = Base.decode16!(hex, case: :lower)
+
+      assert byte_size(hex) == 24
+      assert byte_size(decoded) == 12
+    end
+  end
+
+  describe "worker_id/0" do
+    test "should return a random hex" do
+      hex1 = Random.worker_id()
+      hex2 = Random.worker_id()
+
+      assert hex1 != hex2
+    end
+
+    test "should return a lower case hex" do
+      hex = Random.worker_id()
+
+      assert hex == String.downcase(hex)
+    end
+
+    test "should return a random hex based on 12 random bytes" do
+      hex = Random.worker_id()
+      decoded = Base.decode16!(hex, case: :lower)
+
+      assert byte_size(hex) == 16
+      assert byte_size(decoded) == 8
+    end
+  end
+
+  describe "string/0" do
+    test "should return a random hex" do
+      hex1 = Random.string()
+      hex2 = Random.string()
+
+      assert hex1 != hex2
+    end
+  end
+end

--- a/test/support/faktory_test_helpers.ex
+++ b/test/support/faktory_test_helpers.ex
@@ -10,9 +10,4 @@ defmodule FaktoryWorker.FaktoryTestHelpers do
 
     assert get_in(info, ["faktory", "queues", queue_name]) == expected_size
   end
-
-  def random_string() do
-    bytes = :crypto.strong_rand_bytes(12)
-    Base.encode16(bytes)
-  end
 end


### PR DESCRIPTION
Adds support for creating worker connections to faktory.

Tasks
* [x] Add an option to indicate the connection should be a worker
* [x] Add required worker fields to the `HELLO` command