### PR TITLE
Add support for configuring faktory workers to be started

### DIFF
--- a/lib/faktory_worker.ex
+++ b/lib/faktory_worker.ex
@@ -9,7 +9,8 @@ defmodule FaktoryWorker do
 
     children = [
       {FaktoryWorker.Pool, opts},
-      {FaktoryWorker.PushPipeline, opts}
+      {FaktoryWorker.PushPipeline, opts},
+      {FaktoryWorker.WorkerSupervisor, opts}
     ]
 
     %{

--- a/lib/faktory_worker/job.ex
+++ b/lib/faktory_worker/job.ex
@@ -18,6 +18,8 @@ defmodule FaktoryWorker.Job do
     alias FaktoryWorker.Job
 
     quote do
+      def worker_config(), do: unquote(using_opts)
+
       def perform_async(job, opts \\ []) do
         opts = Keyword.merge(unquote(using_opts), opts)
 

--- a/lib/faktory_worker/worker.ex
+++ b/lib/faktory_worker/worker.ex
@@ -1,0 +1,28 @@
+defmodule FaktoryWorker.Worker do
+  @moduledoc false
+
+  use GenServer
+
+  @spec start_link(opts :: keyword()) :: GenServer.on_start()
+  def start_link(opts) do
+    GenServer.start_link(__MODULE__, opts, name: name_from_opts(opts))
+  end
+
+  @spec child_spec(opts :: keyword()) :: Supervisor.child_spec()
+  def child_spec(opts) do
+    %{
+      id: name_from_opts(opts),
+      start: {__MODULE__, :start_link, [opts]},
+      type: :worker
+    }
+  end
+
+  @impl true
+  def init(_opts) do
+    {:ok, []}
+  end
+
+  defp name_from_opts(opts) do
+    Keyword.get(opts, :name, __MODULE__)
+  end
+end

--- a/lib/faktory_worker/worker_supervisor.ex
+++ b/lib/faktory_worker/worker_supervisor.ex
@@ -1,0 +1,38 @@
+defmodule FaktoryWorker.WorkerSupervisor do
+  @moduledoc false
+
+  use Supervisor
+
+  alias FaktoryWorker.Random
+
+  @spec start_link(opts :: keyword()) :: Supervisor.on_start()
+  def start_link(opts) do
+    name = Keyword.get(opts, :name)
+    Supervisor.start_link(__MODULE__, opts, name: :"#{name}_worker_supervisor")
+  end
+
+  @impl true
+  def init(opts) do
+    children =
+      opts
+      |> Keyword.get(:workers, [])
+      |> Enum.map(&map_worker/1)
+      |> List.flatten()
+
+    Supervisor.init(children, strategy: :one_for_one)
+  end
+
+  defp map_worker(worker_module) do
+    worker_opts = worker_module.worker_config()
+    concurrency = Keyword.get(worker_opts, :concurrency, 1)
+
+    Enum.reduce(1..concurrency, [], fn _, acc ->
+      worker_id = Random.worker_id()
+      worker_name = :"#{worker_module}_#{worker_id}"
+
+      opts = [name: worker_name, worker_id: worker_id]
+
+      [FaktoryWorker.Worker.child_spec(opts) | acc]
+    end)
+  end
+end

--- a/test/faktory_worker/job/job_test.exs
+++ b/test/faktory_worker/job/job_test.exs
@@ -3,6 +3,12 @@ defmodule FaktoryWorker.Job.JobTest do
 
   alias FaktoryWorker.Job
 
+  defmodule TestWorker do
+    use FaktoryWorker.Job,
+      queue: "test_queue",
+      concurrency: 10
+  end
+
   describe "build_payload/3" do
     test "should create new faktory job struct" do
       data = %{hey: "there!"}
@@ -91,6 +97,15 @@ defmodule FaktoryWorker.Job.JobTest do
       {:error, error} = Job.perform_async(TestPipeline, payload, [])
 
       assert error == "The field 'queue' has an invalid value '123'"
+    end
+  end
+
+  describe "__using__/1" do
+    test "should make the worker config available via worker_config/0" do
+      config = TestWorker.worker_config()
+
+      assert Keyword.get(config, :queue) == "test_queue"
+      assert Keyword.get(config, :concurrency) == 10
     end
   end
 end

--- a/test/faktory_worker_test.exs
+++ b/test/faktory_worker_test.exs
@@ -20,7 +20,8 @@ defmodule FaktoryWorkerTest do
 
       assert config == [
                {FaktoryWorker.Pool, [name: :my_test_faktory]},
-               {FaktoryWorker.PushPipeline, [name: :my_test_faktory]}
+               {FaktoryWorker.PushPipeline, [name: :my_test_faktory]},
+               {FaktoryWorker.WorkerSupervisor, [name: :my_test_faktory]}
              ]
     end
 
@@ -36,7 +37,8 @@ defmodule FaktoryWorkerTest do
 
       assert config == [
                {FaktoryWorker.Pool, [name: FaktoryWorker, pool: [size: 25]]},
-               {FaktoryWorker.PushPipeline, [name: FaktoryWorker, pool: [size: 25]]}
+               {FaktoryWorker.PushPipeline, [name: FaktoryWorker, pool: [size: 25]]},
+               {FaktoryWorker.WorkerSupervisor, [name: FaktoryWorker, pool: [size: 25]]}
              ]
     end
 
@@ -55,6 +57,8 @@ defmodule FaktoryWorkerTest do
                {FaktoryWorker.Pool,
                 [name: FaktoryWorker, connection: [host: "somehost", port: 7519]]},
                {FaktoryWorker.PushPipeline,
+                [name: FaktoryWorker, connection: [host: "somehost", port: 7519]]},
+               {FaktoryWorker.WorkerSupervisor,
                 [name: FaktoryWorker, connection: [host: "somehost", port: 7519]]}
              ]
     end
@@ -68,7 +72,8 @@ defmodule FaktoryWorkerTest do
          [
            [
              {FaktoryWorker.Pool, [name: FaktoryWorker]},
-             {FaktoryWorker.PushPipeline, [name: FaktoryWorker]}
+             {FaktoryWorker.PushPipeline, [name: FaktoryWorker]},
+             {FaktoryWorker.WorkerSupervisor, [name: FaktoryWorker]}
            ],
            [strategy: :one_for_one]
          ]},

--- a/test/worker_supervisor_test.exs
+++ b/test/worker_supervisor_test.exs
@@ -1,0 +1,74 @@
+defmodule FaktoryWorker.WorkerSupervisorTest do
+  use ExUnit.Case
+
+  alias FaktoryWorker.WorkerSupervisor
+
+  defmodule SingleWorker do
+    use FaktoryWorker.Job
+  end
+
+  defmodule MultiWorker do
+    use FaktoryWorker.Job,
+      concurrency: 10
+  end
+
+  describe "start_link/1" do
+    test "should start the supervisor" do
+      opts = [name: FaktoryWorker]
+
+      {:ok, pid} = WorkerSupervisor.start_link(opts)
+
+      assert pid == Process.whereis(FaktoryWorker_worker_supervisor)
+
+      :ok = Supervisor.stop(pid)
+    end
+
+    test "should start the list of specified workers" do
+      opts = [name: FaktoryWorker, workers: [SingleWorker]]
+      {:ok, pid} = WorkerSupervisor.start_link(opts)
+
+      [{worker_name, _, type, [server_module]}] = Supervisor.which_children(pid)
+      [worker_name, worker_id] = split_worker_name(worker_name)
+
+      assert worker_name == "SingleWorker"
+      assert byte_size(worker_id) == 16
+      assert type == :worker
+      assert server_module == FaktoryWorker.Worker
+
+      :ok = Supervisor.stop(pid)
+    end
+
+    test "should start the list of specified workers with concurrency settings" do
+      opts = [name: FaktoryWorker, workers: [SingleWorker, MultiWorker]]
+      {:ok, pid} = WorkerSupervisor.start_link(opts)
+
+      children = Supervisor.which_children(pid)
+
+      %{"SingleWorker" => single_workers, "MultiWorker" => multi_workers} =
+        children
+        |> Enum.group_by(
+          fn {worker_name, _, _, _} ->
+            worker_name
+            |> split_worker_name()
+            |> List.first()
+          end,
+          fn {worker_name, _, _, _} ->
+            worker_name
+            |> split_worker_name()
+            |> List.last()
+          end
+        )
+
+      assert length(children) == 11
+      assert length(single_workers) == 1
+      assert length(multi_workers) == 10
+
+      :ok = Supervisor.stop(pid)
+    end
+  end
+
+  defp split_worker_name(worker_name) do
+    [_, _, worker_name] = Module.split(worker_name)
+    String.split(worker_name, "_")
+  end
+end

--- a/test/worker_test.exs
+++ b/test/worker_test.exs
@@ -1,0 +1,42 @@
+defmodule FaktoryWorker.WorkerTest do
+  use ExUnit.Case
+
+  alias FaktoryWorker.Worker
+
+  describe "child_spec/1" do
+    test "should return a default child_spec" do
+      opts = [name: :test_worker_1]
+      child_spec = Worker.child_spec(opts)
+
+      assert child_spec == %{
+               id: :test_worker_1,
+               start: {FaktoryWorker.Worker, :start_link, [[name: :test_worker_1]]},
+               type: :worker
+             }
+    end
+
+    test "should allow connection config to be specified" do
+      opts = [name: :test_worker_1, connection: [port: 7000]]
+      child_spec = Worker.child_spec(opts)
+
+      assert child_spec == %{
+               id: :test_worker_1,
+               start:
+                 {FaktoryWorker.Worker, :start_link,
+                  [[name: :test_worker_1, connection: [port: 7000]]]},
+               type: :worker
+             }
+    end
+  end
+
+  describe "start_link/1" do
+    test "should start the worker" do
+      opts = [name: :test_worker_1]
+      pid = start_supervised!(Worker.child_spec(opts))
+
+      assert pid == Process.whereis(:test_worker_1)
+
+      :ok = stop_supervised(:test_worker_1)
+    end
+  end
+end


### PR DESCRIPTION
Adds support for configuring a list of faktory workers to be started as part of the supervision tree. This PR solely focuses on defining the worker servers and starting them. It doesn't include anything to do with connecting them to faktory, this will come in a follow up PR.

When defining a module to handle jobs it is now possible to specify an optional concurrency setting (defaults to 1).

```elixir
defmodule MyApp.UploadWorker do
  use FaktoryWorker.Job, concurrency: 5
end
```

This module can then be included in the faktory worker config under the `:workers` key.

```elixir
def start(_, _) do
    children = [
      {FaktoryWorker, workers: [MyApp.UploadWorker]},
    ]

    Supervisor.start_link(children,
      strategy: :one_for_one,
      name: MyApp.Supervisor
    )
  end
```

Now when the app boots up the worker servers will get started.