### PR TITLE
Implement the worker fetch functionality

### DIFF
--- a/lib/faktory_worker.ex
+++ b/lib/faktory_worker.ex
@@ -10,6 +10,7 @@ defmodule FaktoryWorker do
     children = [
       {FaktoryWorker.Pool, opts},
       {FaktoryWorker.PushPipeline, opts},
+      {FaktoryWorker.JobSupervisor, opts},
       {FaktoryWorker.WorkerSupervisor, opts}
     ]
 

--- a/lib/faktory_worker/error_formatter.ex
+++ b/lib/faktory_worker/error_formatter.ex
@@ -1,0 +1,68 @@
+defmodule FaktoryWorker.ErrorFormatter do
+  @moduledoc false
+
+  defmodule FormattedError do
+    defstruct [:type, :message, :stacktrace]
+  end
+
+  def format_error(error, max_stacktrace_length) do
+    {type, message, stacktrace} = split_error_reason(error)
+
+    message = limit_error_length(message)
+
+    stacktrace =
+      stacktrace
+      |> Enum.take(max_stacktrace_length)
+      |> Enum.map(&Exception.format_stacktrace_entry/1)
+
+    %FormattedError{
+      type: type || "Undetected Error Type",
+      message: message,
+      stacktrace: stacktrace
+    }
+  end
+
+  defp split_error_reason({%struct_type{} = struct, stacktrace}) when is_list(stacktrace) do
+    message = Map.get(struct, :message)
+
+    {Atom.to_string(struct_type), message || inspect(struct), stacktrace}
+  end
+
+  defp split_error_reason({%{message: message}, stacktrace})
+       when is_binary(message) and is_list(stacktrace) do
+    {nil, message, stacktrace}
+  end
+
+  defp split_error_reason({{error_type, _} = reason, stacktrace})
+       when is_atom(error_type) and is_list(stacktrace) do
+    {Atom.to_string(error_type), format_reason(reason), stacktrace}
+  end
+
+  defp split_error_reason({reason, stacktrace}) when is_list(stacktrace) do
+    {nil, format_reason(reason), stacktrace}
+  end
+
+  defp split_error_reason(reason) do
+    {nil, format_reason(reason), []}
+  end
+
+  defp format_reason(reason) when is_atom(reason) do
+    Atom.to_string(reason)
+  end
+
+  defp format_reason(reason), do: inspect(reason)
+
+  defp limit_error_length(error) when byte_size(error) > 1000 do
+    reduce_string(error, 1000)
+  end
+
+  defp limit_error_length(error), do: error
+
+  defp reduce_string(string, length) do
+    reduced_string = :binary.part(string, {0, length})
+
+    if String.printable?(reduced_string),
+      do: reduced_string,
+      else: reduce_string(reduced_string, length - 1)
+  end
+end

--- a/lib/faktory_worker/job_supervisor.ex
+++ b/lib/faktory_worker/job_supervisor.ex
@@ -1,0 +1,16 @@
+defmodule FaktoryWorker.JobSupervisor do
+  @moduledoc false
+
+  def child_spec(opts) do
+    name = format_supervisor_name(opts[:name])
+
+    %{
+      id: name,
+      start: {Task.Supervisor, :start_link, [[name: name]]}
+    }
+  end
+
+  def format_supervisor_name(name) when is_atom(name) do
+    :"#{name}_job_supervisor"
+  end
+end

--- a/lib/faktory_worker/protocol.ex
+++ b/lib/faktory_worker/protocol.ex
@@ -6,6 +6,8 @@ defmodule FaktoryWorker.Protocol do
           | {:push, args :: map()}
           | {:beat, worker_id :: String.t()}
           | {:fetch, queues :: [String.t()]}
+          | {:ack, job_id :: String.t()}
+          | {:fail, args :: map()}
           | :info
           | :end
           | :flush
@@ -36,6 +38,14 @@ defmodule FaktoryWorker.Protocol do
 
   def encode_command({:fetch, queues}) do
     encode("FETCH", Enum.join(queues, " "))
+  end
+
+  def encode_command({:ack, job_id}) do
+    encode("ACK", %{jid: job_id})
+  end
+
+  def encode_command({:fail, args}) do
+    encode("FAIL", args)
   end
 
   def encode_command(:info) do

--- a/lib/faktory_worker/worker.ex
+++ b/lib/faktory_worker/worker.ex
@@ -2,21 +2,22 @@ defmodule FaktoryWorker.Worker do
   @moduledoc false
 
   alias FaktoryWorker.ConnectionManager
+  alias FaktoryWorker.ErrorFormatter
 
   @type t :: %__MODULE__{}
 
-  @two_seconds 2000
   @fifteen_seconds 15_000
   @valid_beat_states [:ok, :quiet, :running_job]
 
   defstruct [
     :conn,
+    :disable_fetch,
     :worker_id,
     :worker_state,
-    :worker_server,
+    :worker_module,
     :worker_config,
-    :fetch_interval,
-    :fetch_ref,
+    :job_ref,
+    :job_id,
     :beat_interval,
     :beat_ref
   ]
@@ -25,8 +26,8 @@ defmodule FaktoryWorker.Worker do
   def new(opts) do
     worker_id = Keyword.fetch!(opts, :worker_id)
     worker_module = Keyword.fetch!(opts, :worker_module)
-    fetch_interval = Keyword.get(opts, :fetch_interval, @two_seconds)
     beat_interval = Keyword.get(opts, :beat_interval, @fifteen_seconds)
+    disable_fetch = Keyword.get(opts, :disable_fetch, false)
 
     connection =
       opts
@@ -37,10 +38,11 @@ defmodule FaktoryWorker.Worker do
 
     %__MODULE__{
       conn: connection,
+      disable_fetch: disable_fetch,
       worker_id: worker_id,
       worker_state: :ok,
+      worker_module: worker_module,
       worker_config: worker_module.worker_config(),
-      fetch_interval: fetch_interval,
       beat_interval: beat_interval
     }
     |> schedule_beat()
@@ -54,6 +56,8 @@ defmodule FaktoryWorker.Worker do
     |> handle_end_response(state)
   end
 
+  def send_end(state), do: state
+
   @spec send_beat(state :: __MODULE__.t()) :: __MODULE__.t()
   def send_beat(%{worker_state: worker_state} = state)
       when worker_state in @valid_beat_states do
@@ -66,6 +70,7 @@ defmodule FaktoryWorker.Worker do
 
   def send_beat(state), do: clear_beat_ref(state)
 
+  @spec send_fetch(state :: __MODULE__.t()) :: state :: __MODULE__.t()
   def send_fetch(%{worker_state: worker_state} = state) when worker_state == :ok do
     queues =
       state.worker_config
@@ -78,7 +83,31 @@ defmodule FaktoryWorker.Worker do
     |> schedule_fetch()
   end
 
-  def send_fetch(state), do: clear_fetch_ref(state)
+  def send_fetch(state), do: state
+
+  @spec ack_job(state :: __MODULE__.t(), :ok | {:error, any()}) :: __MODULE__.t()
+  def ack_job(state, :ok) do
+    state.conn
+    |> ConnectionManager.send_command({:ack, state.job_id})
+    |> handle_ack_response(state)
+  end
+
+  def ack_job(state, {:error, reason}) do
+    backtrace_length = Keyword.get(state.worker_config, :backtrace, 30)
+
+    error = ErrorFormatter.format_error(reason, backtrace_length)
+
+    payload = %{
+      jid: state.job_id,
+      errtype: error.type,
+      message: error.message,
+      backtrace: error.stacktrace
+    }
+
+    state.conn
+    |> ConnectionManager.send_command({:fail, payload})
+    |> handle_ack_response(state)
+  end
 
   defp handle_beat_response({{:ok, %{"state" => new_state}}, conn}, state) do
     new_state = String.to_existing_atom(new_state)
@@ -108,20 +137,47 @@ defmodule FaktoryWorker.Worker do
     %{state | conn: conn}
   end
 
-  defp handle_fetch_response({{_, r}, conn}, state) do
-    IO.inspect(r)
-    %{state | conn: conn, worker_state: :running_job}
+  defp handle_fetch_response({{:ok, job}, conn}, state) do
+    job_supervisor =
+      state.worker_config
+      |> faktory_name()
+      |> FaktoryWorker.JobSupervisor.format_supervisor_name()
+
+    job_ref =
+      Task.Supervisor.async_nolink(
+        job_supervisor,
+        state.worker_module,
+        :perform,
+        job["args"],
+        # make this whatever is set for the 'reserve_for' minus 20 seconds
+        shutdown: :infinity
+      )
+
+    %{state | conn: conn, worker_state: :running_job, job_ref: job_ref, job_id: job["jid"]}
   end
 
-  defp clear_fetch_ref(state), do: %{state | fetch_ref: nil}
+  defp schedule_fetch(%{disable_fetch: true} = state), do: state
 
   defp schedule_fetch(%{worker_state: worker_state} = state) when worker_state == :ok do
-    fetch_ref = Process.send_after(self(), :fetch, state.fetch_interval)
-    %{state | fetch_ref: fetch_ref}
+    :ok = Process.send(self(), :fetch, [])
+    state
   end
 
   defp schedule_fetch(state), do: state
 
+  defp handle_ack_response({{:ok, _}, conn}, state) do
+    schedule_fetch(%{state | conn: conn, worker_state: :ok, job_ref: nil, job_id: nil})
+  end
+
+  defp handle_ack_response({{:error, _}, conn}, state) do
+    # todo: need to work out what we should do here
+    %{state | conn: conn}
+  end
+
   defp format_queue_for_command(queue) when is_binary(queue), do: [queue]
   defp format_queue_for_command(queues), do: queues
+
+  defp faktory_name(opts) do
+    Keyword.get(opts, :faktory_name, FaktoryWorker)
+  end
 end

--- a/lib/faktory_worker/worker/server.ex
+++ b/lib/faktory_worker/worker/server.ex
@@ -44,6 +44,19 @@ defmodule FaktoryWorker.Worker.Server do
   end
 
   @impl true
+  def handle_info({job_ref, _}, state) when is_reference(job_ref) do
+    Process.demonitor(job_ref, [:flush])
+    state = Worker.ack_job(state, :ok)
+    {:noreply, state}
+  end
+
+  @impl true
+  def handle_info({:DOWN, _job_ref, :process, _pid, reason}, state) do
+    state = Worker.ack_job(state, {:error, reason})
+    {:noreply, state}
+  end
+
+  @impl true
   def terminate(_reason, state) do
     Worker.send_end(state)
   end

--- a/lib/faktory_worker/worker/server.ex
+++ b/lib/faktory_worker/worker/server.ex
@@ -27,13 +27,19 @@ defmodule FaktoryWorker.Worker.Server do
 
   @impl true
   def handle_continue({:setup_connection, opts}, _) do
-    worker = Worker.new(opts, self())
+    worker = Worker.new(opts)
     {:noreply, worker}
   end
 
   @impl true
   def handle_info(:beat, state) do
     state = Worker.send_beat(state)
+    {:noreply, state}
+  end
+
+  @impl true
+  def handle_info(:fetch, state) do
+    state = Worker.send_fetch(state)
     {:noreply, state}
   end
 

--- a/lib/faktory_worker/worker_supervisor.ex
+++ b/lib/faktory_worker/worker_supervisor.ex
@@ -25,12 +25,18 @@ defmodule FaktoryWorker.WorkerSupervisor do
   defp map_worker(worker_module) do
     worker_opts = worker_module.worker_config()
     concurrency = Keyword.get(worker_opts, :concurrency, 1)
+    disable_fetch = Keyword.get(worker_opts, :disable_fetch, false)
 
     Enum.reduce(1..concurrency, [], fn _, acc ->
       worker_id = Random.worker_id()
       worker_name = :"#{worker_module}_#{worker_id}"
 
-      opts = [name: worker_name, worker_id: worker_id, worker_module: worker_module]
+      opts = [
+        name: worker_name,
+        worker_id: worker_id,
+        worker_module: worker_module,
+        disable_fetch: disable_fetch
+      ]
 
       [FaktoryWorker.Worker.Server.child_spec(opts) | acc]
     end)

--- a/lib/faktory_worker/worker_supervisor.ex
+++ b/lib/faktory_worker/worker_supervisor.ex
@@ -30,7 +30,7 @@ defmodule FaktoryWorker.WorkerSupervisor do
       worker_id = Random.worker_id()
       worker_name = :"#{worker_module}_#{worker_id}"
 
-      opts = [name: worker_name, worker_id: worker_id]
+      opts = [name: worker_name, worker_id: worker_id, worker_module: worker_module]
 
       [FaktoryWorker.Worker.Server.child_spec(opts) | acc]
     end)

--- a/test/faktory_worker/error_formatter_test.exs
+++ b/test/faktory_worker/error_formatter_test.exs
@@ -1,0 +1,112 @@
+defmodule FaktoryWorker.ErrorFormatterTest do
+  use ExUnit.Case
+
+  alias FaktoryWorker.ErrorFormatter
+  alias FaktoryWorker.ErrorFormatter.FormattedError
+
+  describe "format_error/2" do
+    @stacktrace [
+      {TestApp.Worker, :perform, 1, [file: 'lib/worker.ex', line: 9]},
+      {Task.Supervised, :invoke_mfa, 2, [file: 'lib/task/supervised.ex', line: 90]},
+      {Task.Supervised, :reply, 5, [file: 'lib/task/supervised.ex', line: 35]},
+      {:proc_lib, :init_p_do_apply, 3, [file: 'proc_lib.erl', line: 249]}
+    ]
+
+    @formatted_stacktrace [
+      "lib/worker.ex:9: TestApp.Worker.perform/1",
+      "(elixir) lib/task/supervised.ex:90: Task.Supervised.invoke_mfa/2",
+      "(elixir) lib/task/supervised.ex:35: Task.Supervised.reply/5",
+      "(stdlib) proc_lib.erl:249: :proc_lib.init_p_do_apply/3"
+    ]
+
+    test "should return a formatted error for an exception" do
+      error = %RuntimeError{message: "It went bang!"}
+
+      formatted_error = ErrorFormatter.format_error({error, @stacktrace}, 10)
+
+      assert formatted_error == %FormattedError{
+               type: "Elixir.RuntimeError",
+               message: "It went bang!",
+               stacktrace: @formatted_stacktrace
+             }
+    end
+
+    test "should return a formatted error for an a map with a message attribute" do
+      error = %{message: "It went bang!"}
+
+      formatted_error = ErrorFormatter.format_error({error, @stacktrace}, 10)
+
+      assert formatted_error == %FormattedError{
+               type: "Undetected Error Type",
+               message: "It went bang!",
+               stacktrace: @formatted_stacktrace
+             }
+    end
+
+    test "should return a formatted error for an a tuple with an atom error type" do
+      error = {:badmatch, "123"}
+
+      formatted_error = ErrorFormatter.format_error({error, @stacktrace}, 10)
+
+      assert formatted_error == %FormattedError{
+               type: "badmatch",
+               message: "{:badmatch, \"123\"}",
+               stacktrace: @formatted_stacktrace
+             }
+    end
+
+    test "should return a formatted error for an unkown error type with a stacktrace" do
+      error = :exit
+
+      formatted_error = ErrorFormatter.format_error({error, @stacktrace}, 10)
+
+      assert formatted_error == %FormattedError{
+               type: "Undetected Error Type",
+               message: "exit",
+               stacktrace: @formatted_stacktrace
+             }
+    end
+
+    test "should return a formatted error for an unkown error type without a stacktrace" do
+      error = :exit
+
+      formatted_error = ErrorFormatter.format_error(error, 10)
+
+      assert formatted_error == %FormattedError{
+               type: "Undetected Error Type",
+               message: "exit",
+               stacktrace: []
+             }
+    end
+
+    test "should limit the length of the stacktrace" do
+      %{stacktrace: stacktrace} = ErrorFormatter.format_error({:exit, @stacktrace}, 2)
+
+      assert length(stacktrace) == 2
+    end
+
+    test "should limit the error message length to 1000 bytes" do
+      error = %RuntimeError{message: String.duplicate("A", 1001)}
+
+      %{message: message} = ErrorFormatter.format_error({error, @stacktrace}, 2)
+
+      assert byte_size(message) == 1000
+    end
+
+    test "should limit the error message length to less than 1000 bytes when truncating renders an invalid character" do
+      # this string will be 1001 bytes since the 'ñ' using 2 bytes
+      error_message = "#{String.duplicate("A", 999)}ñ"
+      error = %RuntimeError{message: error_message}
+
+      %{message: message} = ErrorFormatter.format_error({error, @stacktrace}, 2)
+
+      assert byte_size(message) == 999
+    end
+
+    test "should use a default error type when the type is unknown" do
+      %{type: type} = ErrorFormatter.format_error({:error, @stacktrace}, 10)
+
+      assert type == "Undetected Error Type"
+    end
+  end
+end

--- a/test/faktory_worker/job/job_integration_test.exs
+++ b/test/faktory_worker/job/job_integration_test.exs
@@ -5,24 +5,22 @@ defmodule FaktoryWorker.JobIntegrationTest do
 
   alias FaktoryWorker.Job
   alias FaktoryWorker.Random
+  alias FaktoryWorker.DefaultWorker
+
+  setup :flush_faktory!
 
   describe "perform_async/3" do
     test "should send a new job to faktory" do
       faktory_name = :"Test_#{Random.string()}"
       start_supervised!({FaktoryWorker, name: faktory_name, pool: [size: 1]})
 
-      queue_name = Random.string()
+      opts = [faktory_name: faktory_name]
 
-      opts = [
-        queue: queue_name,
-        faktory_name: faktory_name
-      ]
-
-      job = Job.build_payload(SomeWorker, %{hey: "there!"}, opts)
+      job = Job.build_payload(DefaultWorker, %{hey: "there!"}, opts)
 
       Job.perform_async(job, opts)
 
-      assert_queue_size(queue_name, 1)
+      assert_queue_size("default", 1)
 
       :ok = stop_supervised(faktory_name)
     end

--- a/test/faktory_worker/job_supervisor_test.exs
+++ b/test/faktory_worker/job_supervisor_test.exs
@@ -1,0 +1,35 @@
+defmodule FaktoryWorker.JobSupervisorTest do
+  use ExUnit.Case
+
+  alias FaktoryWorker.JobSupervisor
+
+  describe "child_spec/1" do
+    test "should return a default child_spec" do
+      opts = [name: FaktoryWorker]
+      child_spec = JobSupervisor.child_spec(opts)
+
+      assert child_spec == %{
+               id: FaktoryWorker_job_supervisor,
+               start: {Task.Supervisor, :start_link, [[name: FaktoryWorker_job_supervisor]]}
+             }
+    end
+
+    test "should allow a custom name to be specified" do
+      opts = [name: :test_faktory]
+      child_spec = JobSupervisor.child_spec(opts)
+
+      assert child_spec == %{
+               id: :test_faktory_job_supervisor,
+               start: {Task.Supervisor, :start_link, [[name: :test_faktory_job_supervisor]]}
+             }
+    end
+  end
+
+  describe "format_supervisor_name/1" do
+    test "should return the full job supervisor name" do
+      name = JobSupervisor.format_supervisor_name(:test_faktory)
+
+      assert name == :test_faktory_job_supervisor
+    end
+  end
+end

--- a/test/faktory_worker/protocol_test.exs
+++ b/test/faktory_worker/protocol_test.exs
@@ -47,6 +47,18 @@ defmodule FaktoryWorker.ProtocolTest do
       assert command == "FLUSH\r\n"
     end
 
+    test "should encode the 'FETCH' command with a list of queues" do
+      {:ok, command} = Protocol.encode_command({:fetch, ["queue_one", "queue_two"]})
+
+      assert command == "FETCH queue_one queue_two\r\n"
+    end
+
+    test "should encode the 'FETCH' command with default queue when list of queues is empty" do
+      {:ok, command} = Protocol.encode_command({:fetch, []})
+
+      assert command == "FETCH default\r\n"
+    end
+
     test "should return an error when attempting to encode bad data" do
       {:error, reason} = Protocol.encode_command({:hello, {:v, 2}})
 
@@ -77,6 +89,12 @@ defmodule FaktoryWorker.ProtocolTest do
       {:ok, resposne} = Protocol.decode_response("$592\r\n")
 
       assert resposne == {:bulk_string, 594}
+    end
+
+    test "should decode a null bulk string response" do
+      {:ok, resposne} = Protocol.decode_response("$-1\r\n")
+
+      assert resposne == :no_content
     end
 
     test "should decode bulk string response" do

--- a/test/faktory_worker/protocol_test.exs
+++ b/test/faktory_worker/protocol_test.exs
@@ -59,6 +59,26 @@ defmodule FaktoryWorker.ProtocolTest do
       assert command == "FETCH default\r\n"
     end
 
+    test "should encode the 'ACK' command" do
+      {:ok, command} = Protocol.encode_command({:ack, "1234567890"})
+
+      assert command == "ACK {\"jid\":\"1234567890\"}\r\n"
+    end
+
+    test "should encode the 'FAIL' command" do
+      payload = %{
+        jid: "1234567890",
+        errtype: "Some error",
+        message: "It went bang!",
+        backtrace: ["file2.ex, line: 34", "file.ex, line: 1"]
+      }
+
+      {:ok, command} = Protocol.encode_command({:fail, payload})
+
+      assert command ==
+               "FAIL {\"backtrace\":[\"file2.ex, line: 34\",\"file.ex, line: 1\"],\"errtype\":\"Some error\",\"jid\":\"1234567890\",\"message\":\"It went bang!\"}\r\n"
+    end
+
     test "should return an error when attempting to encode bad data" do
       {:error, reason} = Protocol.encode_command({:hello, {:v, 2}})
 

--- a/test/faktory_worker/push_pipeline/acknowledger_integration_test.exs
+++ b/test/faktory_worker/push_pipeline/acknowledger_integration_test.exs
@@ -6,27 +6,29 @@ defmodule FaktoryWorker.PushPipeline.AcknowledgerIntegrationTest do
   alias FaktoryWorker.Job
   alias FaktoryWorker.PushPipeline.Acknowledger
   alias FaktoryWorker.Random
+  alias FaktoryWorker.DefaultWorker
+
+  setup :flush_faktory!
 
   describe "ack/3" do
     test "should requeue a failed jobs" do
       faktory_name = :"Test_#{Random.string()}"
-      queue_name = Random.string()
       pipeline_name = FaktoryWorker.PushPipeline.format_pipeline_name(faktory_name)
 
       job = %{hey: "there!"}
-      opts = [queue: queue_name, faktory_name: faktory_name]
+      opts = [faktory_name: faktory_name]
 
-      payload1 = Job.build_payload(TestWorker, job, opts)
+      payload1 = Job.build_payload(DefaultWorker, job, opts)
       message1 = %{data: {pipeline_name, payload1}}
 
-      payload2 = Job.build_payload(TestWorker, job, opts)
+      payload2 = Job.build_payload(DefaultWorker, job, opts)
       message2 = %{data: {pipeline_name, payload2}}
 
       start_supervised!({FaktoryWorker, name: faktory_name, pool: [size: 2]})
 
       :ok = Acknowledger.ack(:test_ref, [], [message1, message2])
 
-      assert_queue_size(queue_name, 2)
+      assert_queue_size("default", 2)
 
       :ok = stop_supervised(faktory_name)
     end

--- a/test/faktory_worker/worker/server_integration_test.exs
+++ b/test/faktory_worker/worker/server_integration_test.exs
@@ -1,11 +1,13 @@
 defmodule FaktoryWorker.Worker.ServerIntegrationTest do
   use ExUnit.Case, async: false
 
+  import FaktoryWorker.FaktoryTestHelpers
+
   alias FaktoryWorker.Worker.Server
   alias FaktoryWorker.Random
   alias FaktoryWorker.TestQueueWorker
 
-  # todo: flush before each test
+  setup :flush_faktory!
 
   describe "start_link/1" do
     test "should start the worker server and connect to faktory" do

--- a/test/faktory_worker/worker/server_integration_test.exs
+++ b/test/faktory_worker/worker/server_integration_test.exs
@@ -3,10 +3,11 @@ defmodule FaktoryWorker.Worker.ServerIntegrationTest do
 
   alias FaktoryWorker.Worker.Server
   alias FaktoryWorker.Random
+  alias FaktoryWorker.TestQueueWorker
 
   describe "start_link/1" do
     test "should start the worker server and connect to faktory" do
-      opts = [name: :test_worker_1, worker_id: Random.worker_id()]
+      opts = [name: :test_worker_1, worker_id: Random.worker_id(), worker_module: TestQueueWorker]
       pid = start_supervised!(Server.child_spec(opts))
 
       %{conn: connection_manager} = :sys.get_state(pid)

--- a/test/faktory_worker/worker/server_integration_test.exs
+++ b/test/faktory_worker/worker/server_integration_test.exs
@@ -1,13 +1,21 @@
 defmodule FaktoryWorker.Worker.ServerIntegrationTest do
-  use ExUnit.Case
+  use ExUnit.Case, async: false
 
   alias FaktoryWorker.Worker.Server
   alias FaktoryWorker.Random
   alias FaktoryWorker.TestQueueWorker
 
+  # todo: flush before each test
+
   describe "start_link/1" do
     test "should start the worker server and connect to faktory" do
-      opts = [name: :test_worker_1, worker_id: Random.worker_id(), worker_module: TestQueueWorker]
+      opts = [
+        name: :test_worker_1,
+        worker_id: Random.worker_id(),
+        worker_module: TestQueueWorker,
+        disable_fetch: true
+      ]
+
       pid = start_supervised!(Server.child_spec(opts))
 
       %{conn: connection_manager} = :sys.get_state(pid)
@@ -18,6 +26,23 @@ defmodule FaktoryWorker.Worker.ServerIntegrationTest do
       assert is_port(connection_manager.conn.socket)
 
       :ok = stop_supervised(:test_worker_1)
+    end
+  end
+
+  describe "worker lifecyle" do
+    test "should send multiple 'FETCH' commands" do
+      start_supervised!(FaktoryWorker.child_spec(pool: [size: 1], workers: [TestQueueWorker]))
+
+      job1 = %{"job" => "one", "_send_to_" => inspect(self())}
+      job2 = %{"job" => "two", "_send_to_" => inspect(self())}
+
+      TestQueueWorker.perform_async(job1)
+      TestQueueWorker.perform_async(job2)
+
+      assert_receive {TestQueueWorker, :perform, %{"job" => "one"}}, 50
+      assert_receive {TestQueueWorker, :perform, %{"job" => "two"}}, 50
+
+      :ok = stop_supervised(FaktoryWorker)
     end
   end
 end

--- a/test/faktory_worker/worker/server_test.exs
+++ b/test/faktory_worker/worker/server_test.exs
@@ -7,6 +7,7 @@ defmodule FaktoryWorker.Worker.ServerTest do
 
   alias FaktoryWorker.Worker.Server
   alias FaktoryWorker.Random
+  alias FaktoryWorker.TestQueueWorker
 
   setup :set_mox_global
   setup :verify_on_exit!
@@ -39,7 +40,7 @@ defmodule FaktoryWorker.Worker.ServerTest do
 
   describe "start_link/1" do
     test "should start the worker server" do
-      opts = [name: :test_worker_1, worker_id: Random.worker_id()]
+      opts = [name: :test_worker_1, worker_id: Random.worker_id(), worker_module: TestQueueWorker]
       pid = start_supervised!(Server.child_spec(opts))
 
       assert pid == Process.whereis(:test_worker_1)
@@ -54,6 +55,7 @@ defmodule FaktoryWorker.Worker.ServerTest do
       opts = [
         name: :test_worker_1,
         worker_id: Random.worker_id(),
+        worker_module: TestQueueWorker,
         connection: [socket_handler: FaktoryWorker.SocketMock]
       ]
 
@@ -78,6 +80,7 @@ defmodule FaktoryWorker.Worker.ServerTest do
       opts = [
         name: :test_worker_1,
         worker_id: Random.worker_id(),
+        worker_module: TestQueueWorker,
         connection: [socket_handler: FaktoryWorker.SocketMock]
       ]
 
@@ -114,6 +117,7 @@ defmodule FaktoryWorker.Worker.ServerTest do
       opts = [
         name: :test_worker_1,
         worker_id: Random.worker_id(),
+        worker_module: TestQueueWorker,
         beat_interval: 1,
         connection: [socket_handler: FaktoryWorker.SocketMock]
       ]

--- a/test/faktory_worker/worker/server_test.exs
+++ b/test/faktory_worker/worker/server_test.exs
@@ -56,6 +56,7 @@ defmodule FaktoryWorker.Worker.ServerTest do
         name: :test_worker_1,
         worker_id: Random.worker_id(),
         worker_module: TestQueueWorker,
+        disable_fetch: true,
         connection: [socket_handler: FaktoryWorker.SocketMock]
       ]
 
@@ -91,7 +92,7 @@ defmodule FaktoryWorker.Worker.ServerTest do
     end
   end
 
-  describe "worker lidecycle" do
+  describe "worker lifecycle" do
     test "should issue regular 'BEAT' commands" do
       worker_connection_mox()
 
@@ -119,6 +120,7 @@ defmodule FaktoryWorker.Worker.ServerTest do
         worker_id: Random.worker_id(),
         worker_module: TestQueueWorker,
         beat_interval: 1,
+        disable_fetch: true,
         connection: [socket_handler: FaktoryWorker.SocketMock]
       ]
 
@@ -128,6 +130,88 @@ defmodule FaktoryWorker.Worker.ServerTest do
 
       # sleep 5 milliseconds to allow both beats to occur
       Process.sleep(5)
+
+      :ok = stop_supervised(:test_worker_1)
+    end
+
+    test "should send 'ACK' command when a job completes successfully" do
+      job_id = "f47ccc395ef9d9646118434f"
+      ack_command = "ACK {\"jid\":\"#{job_id}\"}\r\n"
+
+      worker_connection_mox()
+
+      expect(FaktoryWorker.SocketMock, :send, fn _, ^ack_command ->
+        :ok
+      end)
+
+      expect(FaktoryWorker.SocketMock, :recv, fn _ ->
+        {:ok, "+OK\r\n"}
+      end)
+
+      connection_close_mox()
+
+      opts = [
+        name: :test_worker_1,
+        worker_id: Random.worker_id(),
+        worker_module: TestQueueWorker,
+        disable_fetch: true,
+        connection: [socket_handler: FaktoryWorker.SocketMock]
+      ]
+
+      pid = start_supervised!(Server.child_spec(opts))
+
+      :sys.replace_state(pid, fn state ->
+        Map.put(state, :job_id, job_id)
+      end)
+
+      Process.send(pid, {:erlang.make_ref(), :ok}, [])
+
+      :ok = stop_supervised(:test_worker_1)
+    end
+
+    test "should send 'FAIL' command when a job fails to complete" do
+      job_id = "f47ccc395ef9d9646118434f"
+
+      {:current_stacktrace, stacktrace} = Process.info(self(), :current_stacktrace)
+
+      fail_payload = %{
+        jid: job_id,
+        errtype: "Elixir.RuntimeError",
+        message: "It went bang!",
+        backtrace: Enum.map(stacktrace, &Exception.format_stacktrace_entry/1)
+      }
+
+      fail_command = "FAIL #{Jason.encode!(fail_payload)}\r\n"
+
+      worker_connection_mox()
+
+      expect(FaktoryWorker.SocketMock, :send, fn _, ^fail_command ->
+        :ok
+      end)
+
+      expect(FaktoryWorker.SocketMock, :recv, fn _ ->
+        {:ok, "+OK\r\n"}
+      end)
+
+      connection_close_mox()
+
+      opts = [
+        name: :test_worker_1,
+        worker_id: Random.worker_id(),
+        worker_module: TestQueueWorker,
+        disable_fetch: true,
+        connection: [socket_handler: FaktoryWorker.SocketMock]
+      ]
+
+      pid = start_supervised!(Server.child_spec(opts))
+
+      :sys.replace_state(pid, fn state ->
+        Map.put(state, :job_id, job_id)
+      end)
+
+      reason = {%RuntimeError{message: "It went bang!"}, stacktrace}
+
+      Process.send(pid, {:DOWN, :erlang.make_ref(), :process, self(), reason}, [])
 
       :ok = stop_supervised(:test_worker_1)
     end

--- a/test/faktory_worker/worker_supervisor_test.exs
+++ b/test/faktory_worker/worker_supervisor_test.exs
@@ -4,12 +4,18 @@ defmodule FaktoryWorker.WorkerSupervisorTest do
   alias FaktoryWorker.WorkerSupervisor
 
   defmodule SingleWorker do
-    use FaktoryWorker.Job
+    use FaktoryWorker.Job,
+      disable_fetch: true
+
+    def perform(_), do: :ok
   end
 
   defmodule MultiWorker do
     use FaktoryWorker.Job,
+      disable_fetch: true,
       concurrency: 10
+
+    def perform(_), do: :ok
   end
 
   describe "start_link/1" do
@@ -41,7 +47,6 @@ defmodule FaktoryWorker.WorkerSupervisorTest do
     test "should start the list of specified workers with concurrency settings" do
       opts = [name: FaktoryWorker, workers: [SingleWorker, MultiWorker]]
       {:ok, pid} = WorkerSupervisor.start_link(opts)
-
       children = Supervisor.which_children(pid)
 
       %{"SingleWorker" => single_workers, "MultiWorker" => multi_workers} =

--- a/test/faktory_worker/worker_test.exs
+++ b/test/faktory_worker/worker_test.exs
@@ -6,7 +6,9 @@ defmodule FaktoryWorker.WorkerTest do
 
   alias FaktoryWorker.Worker
   alias FaktoryWorker.Random
+  alias FaktoryWorker.{DefaultWorker, TestQueueWorker}
 
+  @two_seconds 2000
   @fifteen_seconds 15_000
 
   setup :verify_on_exit!
@@ -14,19 +16,27 @@ defmodule FaktoryWorker.WorkerTest do
   describe "new/2" do
     test "should return a worker struct" do
       worker_id = Random.worker_id()
-      opts = [worker_id: worker_id]
+      opts = [worker_id: worker_id, worker_module: TestQueueWorker]
 
-      worker = Worker.new(opts, self())
+      worker = Worker.new(opts)
 
       assert worker.worker_id == worker_id
       assert worker.worker_state == :ok
-      assert worker.worker_server == self()
       assert worker.beat_interval == @fifteen_seconds
+      assert worker.fetch_interval == @two_seconds
     end
 
     test "should raise if no worker id is provided" do
-      assert_raise KeyError, fn ->
-        Worker.new([], self())
+      assert_raise KeyError, "key :worker_id not found in: []", fn ->
+        Worker.new([])
+      end
+    end
+
+    test "should raise if no worker module is provided" do
+      opts = [worker_id: Random.worker_id()]
+
+      assert_raise KeyError, "key :worker_module not found in: #{inspect(opts)}", fn ->
+        Worker.new(opts)
       end
     end
 
@@ -35,20 +45,29 @@ defmodule FaktoryWorker.WorkerTest do
 
       opts = [
         worker_id: Random.worker_id(),
+        worker_module: TestQueueWorker,
         connection: [socket_handler: FaktoryWorker.SocketMock]
       ]
 
-      worker = Worker.new(opts, self())
+      worker = Worker.new(opts)
 
       assert worker.conn != nil
     end
 
     test "should schedule a beat to be triggered" do
-      opts = [worker_id: Random.worker_id()]
+      opts = [worker_id: Random.worker_id(), worker_module: TestQueueWorker]
 
-      worker = Worker.new(opts, self())
+      worker = Worker.new(opts)
 
       assert is_reference(worker.beat_ref)
+    end
+
+    test "should schedule a fetch to be triggered" do
+      opts = [worker_id: Random.worker_id(), worker_module: TestQueueWorker]
+
+      worker = Worker.new(opts)
+
+      assert is_reference(worker.fetch_ref)
     end
   end
 
@@ -69,10 +88,11 @@ defmodule FaktoryWorker.WorkerTest do
 
       opts = [
         worker_id: worker_id,
+        worker_module: TestQueueWorker,
         connection: [socket_handler: FaktoryWorker.SocketMock]
       ]
 
-      worker = Worker.new(opts, self())
+      worker = Worker.new(opts)
 
       result = Worker.send_beat(worker)
 
@@ -96,13 +116,45 @@ defmodule FaktoryWorker.WorkerTest do
 
       opts = [
         worker_id: worker_id,
+        worker_module: TestQueueWorker,
         connection: [socket_handler: FaktoryWorker.SocketMock]
       ]
 
       worker =
         opts
-        |> Worker.new(self())
+        |> Worker.new()
         |> Map.put(:worker_state, :quiet)
+
+      result = Worker.send_beat(worker)
+
+      assert is_reference(result.beat_ref)
+      assert result.beat_ref != worker.beat_ref
+    end
+
+    test "should send a beat command and schedule next beat when state is ':running_job'" do
+      worker_id = Random.worker_id()
+      beat_command = "BEAT {\"wid\":\"#{worker_id}\"}\r\n"
+
+      worker_connection_mox()
+
+      expect(FaktoryWorker.SocketMock, :send, fn _, ^beat_command ->
+        :ok
+      end)
+
+      expect(FaktoryWorker.SocketMock, :recv, fn _ ->
+        {:ok, "+OK\r\n"}
+      end)
+
+      opts = [
+        worker_id: worker_id,
+        worker_module: TestQueueWorker,
+        connection: [socket_handler: FaktoryWorker.SocketMock]
+      ]
+
+      worker =
+        opts
+        |> Worker.new()
+        |> Map.put(:worker_state, :running_job)
 
       result = Worker.send_beat(worker)
 
@@ -117,15 +169,15 @@ defmodule FaktoryWorker.WorkerTest do
 
       opts = [
         worker_id: worker_id,
+        worker_module: TestQueueWorker,
         connection: [socket_handler: FaktoryWorker.SocketMock]
       ]
 
-      worker =
+      result =
         opts
-        |> Worker.new(self())
+        |> Worker.new()
         |> Map.put(:worker_state, :terminate)
-
-      result = Worker.send_beat(worker)
+        |> Worker.send_beat()
 
       assert result.beat_ref == nil
     end
@@ -146,12 +198,13 @@ defmodule FaktoryWorker.WorkerTest do
 
       opts = [
         worker_id: worker_id,
+        worker_module: TestQueueWorker,
         connection: [socket_handler: FaktoryWorker.SocketMock]
       ]
 
       result =
         opts
-        |> Worker.new(self())
+        |> Worker.new()
         |> Worker.send_beat()
 
       assert result.worker_state == :quiet
@@ -173,12 +226,13 @@ defmodule FaktoryWorker.WorkerTest do
 
       opts = [
         worker_id: worker_id,
+        worker_module: TestQueueWorker,
         connection: [socket_handler: FaktoryWorker.SocketMock]
       ]
 
       result =
         opts
-        |> Worker.new(self())
+        |> Worker.new()
         |> Worker.send_beat()
 
       assert result.worker_state == :terminate
@@ -203,16 +257,184 @@ defmodule FaktoryWorker.WorkerTest do
 
       opts = [
         worker_id: Random.worker_id(),
+        worker_module: TestQueueWorker,
         connection: [socket_handler: FaktoryWorker.SocketMock]
       ]
 
       result =
         opts
-        |> Worker.new(self())
+        |> Worker.new()
         |> Worker.send_end()
 
       assert result.conn == nil
       assert result.worker_state == :ended
+    end
+  end
+
+  describe "send_fetch/1" do
+    test "should send a fetch command and schedule next fetch when state is ':ok'" do
+      worker_connection_mox()
+
+      expect(FaktoryWorker.SocketMock, :send, fn _, "FETCH test_queue\r\n" ->
+        :ok
+      end)
+
+      expect(FaktoryWorker.SocketMock, :recv, fn _ ->
+        {:ok, "$-1\r\n"}
+      end)
+
+      opts = [
+        worker_id: Random.worker_id(),
+        worker_module: TestQueueWorker,
+        connection: [socket_handler: FaktoryWorker.SocketMock]
+      ]
+
+      worker = Worker.new(opts)
+
+      result = Worker.send_fetch(worker)
+
+      assert is_reference(result.fetch_ref)
+      assert result.fetch_ref != worker.fetch_ref
+    end
+
+    test "should not send a fetch command and schedule next fetch when state is ':quiet'" do
+      worker_connection_mox()
+
+      opts = [
+        worker_id: Random.worker_id(),
+        worker_module: TestQueueWorker,
+        connection: [socket_handler: FaktoryWorker.SocketMock]
+      ]
+
+      result =
+        opts
+        |> Worker.new()
+        |> Map.put(:worker_state, :quiet)
+        |> Worker.send_fetch()
+
+      assert result.fetch_ref == nil
+    end
+
+    test "should not send a fetch command and schedule next fetch when state is ':terminate'" do
+      worker_connection_mox()
+
+      opts = [
+        worker_id: Random.worker_id(),
+        worker_module: TestQueueWorker,
+        connection: [socket_handler: FaktoryWorker.SocketMock]
+      ]
+
+      result =
+        opts
+        |> Worker.new()
+        |> Map.put(:worker_state, :terminate)
+        |> Worker.send_fetch()
+
+      assert result.fetch_ref == nil
+    end
+
+    test "should not send a fetch command and schedule next fetch when state is ':running_job'" do
+      worker_connection_mox()
+
+      opts = [
+        worker_id: Random.worker_id(),
+        worker_module: TestQueueWorker,
+        connection: [socket_handler: FaktoryWorker.SocketMock]
+      ]
+
+      result =
+        opts
+        |> Worker.new()
+        |> Map.put(:worker_state, :running_job)
+        |> Worker.send_fetch()
+
+      assert result.fetch_ref == nil
+    end
+
+    test "should send a fetch command without a queue configured" do
+      worker_connection_mox()
+
+      expect(FaktoryWorker.SocketMock, :send, fn _, "FETCH default\r\n" ->
+        :ok
+      end)
+
+      expect(FaktoryWorker.SocketMock, :recv, fn _ ->
+        {:ok, "$-1\r\n"}
+      end)
+
+      opts = [
+        worker_id: Random.worker_id(),
+        worker_module: DefaultWorker,
+        connection: [socket_handler: FaktoryWorker.SocketMock]
+      ]
+
+      opts
+      |> Worker.new()
+      |> Worker.send_fetch()
+    end
+
+    test "should leave the worker state set to ':ok' when there is no job to process" do
+      worker_connection_mox()
+
+      expect(FaktoryWorker.SocketMock, :send, fn _, "FETCH test_queue\r\n" ->
+        :ok
+      end)
+
+      expect(FaktoryWorker.SocketMock, :recv, fn _ ->
+        {:ok, "$-1\r\n"}
+      end)
+
+      opts = [
+        worker_id: Random.worker_id(),
+        worker_module: TestQueueWorker,
+        connection: [socket_handler: FaktoryWorker.SocketMock]
+      ]
+
+      result =
+        opts
+        |> Worker.new()
+        |> Worker.send_fetch()
+
+      assert result.worker_state == :ok
+    end
+
+    test "should set state to ':running_job' when there is a job to process" do
+      worker_connection_mox()
+
+      expect(FaktoryWorker.SocketMock, :send, fn _, "FETCH test_queue\r\n" ->
+        :ok
+      end)
+
+      expect(FaktoryWorker.SocketMock, :recv, fn _ ->
+        {:ok, "$212\r\n"}
+      end)
+
+      expect(FaktoryWorker.SocketMock, :recv, fn _, _ ->
+        job =
+          Jason.encode!(%{
+            "args" => [%{"hey" => "there!"}],
+            "created_at" => "2019-04-09T12:14:07.6550641Z",
+            "enqueued_at" => "2019-04-09T12:14:07.6550883Z",
+            "jid" => "f47ccc395ef9d9646118434f",
+            "jobtype" => "FaktoryWorker.TestQueueWorker",
+            "queue" => "test_queue"
+          })
+
+        {:ok, "#{job}\r\n"}
+      end)
+
+      opts = [
+        worker_id: Random.worker_id(),
+        worker_module: TestQueueWorker,
+        connection: [socket_handler: FaktoryWorker.SocketMock]
+      ]
+
+      result =
+        opts
+        |> Worker.new()
+        |> Worker.send_fetch()
+
+      assert result.worker_state == :running_job
     end
   end
 end

--- a/test/faktory_worker_test.exs
+++ b/test/faktory_worker_test.exs
@@ -21,6 +21,7 @@ defmodule FaktoryWorkerTest do
       assert config == [
                {FaktoryWorker.Pool, [name: :my_test_faktory]},
                {FaktoryWorker.PushPipeline, [name: :my_test_faktory]},
+               {FaktoryWorker.JobSupervisor, [name: :my_test_faktory]},
                {FaktoryWorker.WorkerSupervisor, [name: :my_test_faktory]}
              ]
     end
@@ -38,6 +39,7 @@ defmodule FaktoryWorkerTest do
       assert config == [
                {FaktoryWorker.Pool, [name: FaktoryWorker, pool: [size: 25]]},
                {FaktoryWorker.PushPipeline, [name: FaktoryWorker, pool: [size: 25]]},
+               {FaktoryWorker.JobSupervisor, [name: FaktoryWorker, pool: [size: 25]]},
                {FaktoryWorker.WorkerSupervisor, [name: FaktoryWorker, pool: [size: 25]]}
              ]
     end
@@ -58,6 +60,8 @@ defmodule FaktoryWorkerTest do
                 [name: FaktoryWorker, connection: [host: "somehost", port: 7519]]},
                {FaktoryWorker.PushPipeline,
                 [name: FaktoryWorker, connection: [host: "somehost", port: 7519]]},
+               {FaktoryWorker.JobSupervisor,
+                [name: FaktoryWorker, connection: [host: "somehost", port: 7519]]},
                {FaktoryWorker.WorkerSupervisor,
                 [name: FaktoryWorker, connection: [host: "somehost", port: 7519]]}
              ]
@@ -73,6 +77,7 @@ defmodule FaktoryWorkerTest do
            [
              {FaktoryWorker.Pool, [name: FaktoryWorker]},
              {FaktoryWorker.PushPipeline, [name: FaktoryWorker]},
+             {FaktoryWorker.JobSupervisor, [name: FaktoryWorker]},
              {FaktoryWorker.WorkerSupervisor, [name: FaktoryWorker]}
            ],
            [strategy: :one_for_one]

--- a/test/support/default_worker.ex
+++ b/test/support/default_worker.ex
@@ -1,4 +1,6 @@
 defmodule FaktoryWorker.DefaultWorker do
   @moduledoc false
   use FaktoryWorker.Job
+
+  def perform(_), do: :ok
 end

--- a/test/support/default_worker.ex
+++ b/test/support/default_worker.ex
@@ -1,0 +1,4 @@
+defmodule FaktoryWorker.DefaultWorker do
+  @moduledoc false
+  use FaktoryWorker.Job
+end

--- a/test/support/faktory_test_helpers.ex
+++ b/test/support/faktory_test_helpers.ex
@@ -3,6 +3,12 @@ defmodule FaktoryWorker.FaktoryTestHelpers do
 
   import ExUnit.Assertions
 
+  def flush_faktory!(_context) do
+    {:ok, conn} = FaktoryWorker.Connection.open()
+    {:ok, "OK"} = FaktoryWorker.Connection.send_command(conn, :flush)
+    :ok
+  end
+
   def assert_queue_size(queue_name, expected_size) do
     Process.sleep(50)
     {:ok, connection} = FaktoryWorker.Connection.open()

--- a/test/support/test_queue_worker.ex
+++ b/test/support/test_queue_worker.ex
@@ -1,4 +1,20 @@
 defmodule FaktoryWorker.TestQueueWorker do
   @moduledoc false
   use FaktoryWorker.Job, queue: "test_queue"
+
+  def perform(args) do
+    send_to_process(args["_send_to_"], args)
+  end
+
+  defp send_to_process("#PID" <> pid_string, args) do
+    pid =
+      pid_string
+      |> :erlang.binary_to_list()
+      |> :erlang.list_to_pid()
+
+    send(pid, {__MODULE__, :perform, args})
+    :ok
+  end
+
+  defp send_to_process(_, _), do: :ok
 end

--- a/test/support/test_queue_worker.ex
+++ b/test/support/test_queue_worker.ex
@@ -1,0 +1,4 @@
+defmodule FaktoryWorker.TestQueueWorker do
+  @moduledoc false
+  use FaktoryWorker.Job, queue: "test_queue"
+end


### PR DESCRIPTION
Adds fetch functionality to the worker module.

Tasks
* [x] Implement the `FETCH` command
* [x] Poll faktory using the fetch command
* [x] When a job is returned from faktory run this in it's own process
* [x] Send the `ACK` command to faktory when the job process exits successfully (no exception raised)
* [x] Send the `FAIL` command to faktory when the job process exits unsuccessfully