### PR TITLE
Implement the FLUSH command

### DIFF
--- a/lib/faktory_worker/protocol.ex
+++ b/lib/faktory_worker/protocol.ex
@@ -7,6 +7,7 @@ defmodule FaktoryWorker.Protocol do
           | {:beat, worker_id :: String.t()}
           | :info
           | :end
+          | :flush
 
   @type protocol_response ::
           {:ok, String.t()}
@@ -33,6 +34,10 @@ defmodule FaktoryWorker.Protocol do
 
   def encode_command(:end) do
     encode("END")
+  end
+
+  def encode_command(:flush) do
+    encode("FLUSH")
   end
 
   @spec decode_response(response :: String.t()) :: protocol_response()

--- a/test/faktory_worker/protocol_test.exs
+++ b/test/faktory_worker/protocol_test.exs
@@ -41,6 +41,12 @@ defmodule FaktoryWorker.ProtocolTest do
       assert command == "END\r\n"
     end
 
+    test "should encode the 'FLUSH' command" do
+      {:ok, command} = Protocol.encode_command(:flush)
+
+      assert command == "FLUSH\r\n"
+    end
+
     test "should return an error when attempting to encode bad data" do
       {:error, reason} = Protocol.encode_command({:hello, {:v, 2}})
 


### PR DESCRIPTION
Adds support for the `FLUSH` command.

This command completely clears down faktory and is primarily useful when integration testing.

Fixes #19 