### PR TITLE
Schedule a fetch after failing to ack/fail a job

### DIFF
--- a/lib/faktory_worker/worker.ex
+++ b/lib/faktory_worker/worker.ex
@@ -182,7 +182,7 @@ defmodule FaktoryWorker.Worker do
       "[faktory-worker] Error #{inspect(self())} jid-#{state.job_id} Failed to send a #{ack_type} acknowledgement to faktory"
     )
 
-    %{state | conn: conn}
+    schedule_fetch(%{state | conn: conn, worker_state: :ok, job_ref: nil, job_id: nil})
   end
 
   defp format_queue_for_command(queue) when is_binary(queue), do: [queue]

--- a/test/faktory_worker/worker_test.exs
+++ b/test/faktory_worker/worker_test.exs
@@ -684,8 +684,12 @@ defmodule FaktoryWorker.WorkerTest do
           |> Worker.ack_job(:ok)
         end)
 
+      consume_initial_fetch_message()
+
       assert log_message =~
                "[error] [faktory-worker] Error #{inspect(self())} jid-#{job_id} Failed to send a successful acknowledgement to faktory"
+
+      assert_received :fetch
     end
 
     test "should log when there was an error sending the fail" do
@@ -734,8 +738,12 @@ defmodule FaktoryWorker.WorkerTest do
           |> Worker.ack_job({:error, :exit})
         end)
 
+      consume_initial_fetch_message()
+
       assert log_message =~
                "[error] [faktory-worker] Error #{inspect(self())} jid-#{job_id} Failed to send a failure acknowledgement to faktory"
+
+      assert_received :fetch
     end
   end
 


### PR DESCRIPTION
Fixes an issue where a worker will stop requesting jobs when there is an error sending an `ACK` or `FAIL` for the job.

This makes the assumption that the job outcome cannot be sent to faktory and therefore will resort to letting faktory work out what to do with the job.