### PR TITLE
Add useful logging 

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -1,5 +1,7 @@
 use Mix.Config
 
+config :logger, backends: []
+
 if Mix.env() == :test do
   if System.get_env("CI") do
     config :faktory_worker, :tls_server,

--- a/lib/faktory_worker/connection_manager.ex
+++ b/lib/faktory_worker/connection_manager.ex
@@ -43,6 +43,8 @@ defmodule FaktoryWorker.ConnectionManager do
       # Handle errors from Faktory that should not be tried again, such as
       # unique jobs.
       {{:error, "Halt: " <> reason = error}, state} ->
+        # when we add support for the -NOTUNIQUE response this logging
+        # should be moved into the WorkerLogger module
         log_error(error, command)
 
         {{:ok, reason}, state}

--- a/lib/faktory_worker/worker_logger.ex
+++ b/lib/faktory_worker/worker_logger.ex
@@ -1,0 +1,39 @@
+defmodule FaktoryWorker.WorkerLogger do
+  @moduledoc false
+
+  require Logger
+
+  @spec log_push(jid :: String.t(), args :: any()) :: :ok | {:error, any()}
+  def log_push(jid, args), do: log_info("Enqueued", jid, args)
+
+  @spec log_ack(:ok | :error, jid :: String.t(), args :: any()) :: :ok | {:error, any()}
+  def log_ack(:ok, jid, args), do: log_info("Succeeded", jid, args)
+  def log_ack(:error, jid, args), do: log_info("Failed", jid, args)
+
+  @spec log_beat(:ok | :error, :ok | :error, wid :: String.t()) :: :ok | {:error, any()}
+  # no state change, state == state
+  def log_beat(state, state, _), do: :ok
+  def log_beat(:ok, _, wid), do: log_info("Heartbeat Succeeded", wid)
+  def log_beat(:error, _, wid), do: log_info("Heartbeat Failed", wid)
+
+  @spec log_failed_ack(:ok | :error, jid :: String.t(), args :: any()) :: :ok | {:error, any()}
+  def log_failed_ack(:ok, jid, args) do
+    log_info("Error sending 'ACK' acknowledgement to faktory", jid, args)
+  end
+
+  def log_failed_ack(:error, jid, args) do
+    log_info("Error sending 'FAIL' acknowledgement to faktory", jid, args)
+  end
+
+  defp log_info(message) do
+    Logger.info("[faktory-worker] #{message})")
+  end
+
+  defp log_info(outcome, wid) do
+    log_info("#{outcome} wid-#{wid})")
+  end
+
+  defp log_info(outcome, jid, args) do
+    log_info("#{outcome} jid-#{jid} #{inspect(args)}")
+  end
+end

--- a/test/faktory_worker/worker_logger_test.exs
+++ b/test/faktory_worker/worker_logger_test.exs
@@ -1,0 +1,115 @@
+defmodule FaktoryWorker.WorkerLoggerTest do
+  use ExUnit.Case
+
+  import ExUnit.CaptureLog
+
+  alias FaktoryWorker.WorkerLogger
+  alias FaktoryWorker.Random
+
+  describe "log_push/2" do
+    test "should log a push success" do
+      job_id = Random.job_id()
+      args = %{hey: "there!"}
+
+      log_message =
+        capture_log(fn ->
+          WorkerLogger.log_push(job_id, args)
+        end)
+
+      assert log_message =~ "[faktory-worker] Enqueued jid-#{job_id} #{inspect(args)}"
+    end
+  end
+
+  describe "log_ack/3" do
+    test "should log a successful job ack" do
+      job_id = Random.job_id()
+      args = %{hey: "there!"}
+
+      log_message =
+        capture_log(fn ->
+          WorkerLogger.log_ack(:ok, job_id, args)
+        end)
+
+      assert log_message =~ "[faktory-worker] Succeeded jid-#{job_id} #{inspect(args)}"
+    end
+
+    test "should log a failed job ack" do
+      job_id = Random.job_id()
+      args = %{hey: "there!"}
+
+      log_message =
+        capture_log(fn ->
+          WorkerLogger.log_ack(:error, job_id, args)
+        end)
+
+      assert log_message =~ "[faktory-worker] Failed jid-#{job_id} #{inspect(args)}"
+    end
+  end
+
+  describe "log_failed_ack/3" do
+    test "should log failed to send 'ACK'" do
+      job_id = Random.job_id()
+      args = %{hey: "there!"}
+
+      log_message =
+        capture_log(fn ->
+          WorkerLogger.log_failed_ack(:ok, job_id, args)
+        end)
+
+      assert log_message =~
+               "[faktory-worker] Error sending 'ACK' acknowledgement to faktory jid-#{job_id} #{
+                 inspect(args)
+               }"
+    end
+
+    test "should log failed to send 'FAIL'" do
+      job_id = Random.job_id()
+      args = %{hey: "there!"}
+
+      log_message =
+        capture_log(fn ->
+          WorkerLogger.log_failed_ack(:error, job_id, args)
+        end)
+
+      assert log_message =~
+               "[faktory-worker] Error sending 'FAIL' acknowledgement to faktory jid-#{job_id} #{
+                 inspect(args)
+               }"
+    end
+  end
+
+  describe "log_beat/2" do
+    test "should log a successful beat when previous beat failed" do
+      worker_id = Random.worker_id()
+
+      log_message =
+        capture_log(fn ->
+          WorkerLogger.log_beat(:ok, :error, worker_id)
+        end)
+
+      assert log_message =~ "[faktory-worker] Heartbeat Succeeded wid-#{worker_id}"
+    end
+
+    test "should log a failed beat when previous beat succeeded" do
+      worker_id = Random.worker_id()
+
+      log_message =
+        capture_log(fn ->
+          WorkerLogger.log_beat(:error, :ok, worker_id)
+        end)
+
+      assert log_message =~ "[faktory-worker] Heartbeat Failed wid-#{worker_id}"
+    end
+
+    test "should not log when the beat state did not change" do
+      worker_id = Random.worker_id()
+
+      log_message =
+        capture_log(fn ->
+          WorkerLogger.log_beat(:ok, :ok, worker_id)
+        end)
+
+      assert log_message == ""
+    end
+  end
+end


### PR DESCRIPTION
Update lib to output useful logs using the `:info` log level, fixes #18.

Expected logs
* [x] Log when jobs a enqueued
* [x] Log when jobs run to successful completion (`ACK` message to faktory)
* [x] Log when jobs fail (`FAIL` message to faktory)
* [x] Log when heartbeat success changes (command success, not state changes)
* [x] Refactor all existing places that log to use the new logging format