### PR TITLE
Worker server crashes when receiving a :job_timeout for a completed task

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -1,8 +1,8 @@
 use Mix.Config
 
-config :logger, backends: []
-
 if Mix.env() == :test do
+  config :logger, backends: []
+
   if System.get_env("CI") do
     config :faktory_worker, :tls_server,
       host: "faktory_tls",

--- a/lib/faktory_worker/worker.ex
+++ b/lib/faktory_worker/worker.ex
@@ -186,7 +186,7 @@ defmodule FaktoryWorker.Worker do
     # set a timeout for the job process of the configured reserve_for
     # time minus 20 seconds to ensure the job is stopped before faktory
     # can expire and retry it on the server
-    Process.send_after(self(), :job_timeout, reserve_for - 20)
+    Process.send_after(self(), :job_timeout, (reserve_for - 20) * 1000)
 
     %{
       state

--- a/lib/faktory_worker/worker/server.ex
+++ b/lib/faktory_worker/worker/server.ex
@@ -42,6 +42,10 @@ defmodule FaktoryWorker.Worker.Server do
     {:noreply, state}
   end
 
+  def handle_info(:job_timeout, %{job_ref: nil} = state) do
+    {:noreply, state}
+  end
+
   def handle_info(:job_timeout, state) do
     Process.demonitor(state.job_ref.ref, [:flush])
     state = Worker.stop_job(state)


### PR DESCRIPTION
Update the worker server to handle a `:job_timeout` message being received for a job that has already been completed.

This is partly due to #37 but there is also a chance the timeout message occurs whilst the job completion is being processed (i.e. sending an ack to faktory). This update handles that race condition.