### PR TITLE
Default producer buffer_size and support configuring it

### DIFF
--- a/lib/faktory_worker/push_pipeline.ex
+++ b/lib/faktory_worker/push_pipeline.ex
@@ -17,7 +17,7 @@ defmodule FaktoryWorker.PushPipeline do
       context: %{name: opts[:name]},
       producers: [
         default: [
-          module: {FaktoryWorker.PushPipeline.Producer, []},
+          module: {FaktoryWorker.PushPipeline.Producer, pool_config},
           stages: pool_size
         ]
       ],

--- a/lib/faktory_worker/push_pipeline/producer.ex
+++ b/lib/faktory_worker/push_pipeline/producer.ex
@@ -3,10 +3,14 @@ defmodule FaktoryWorker.PushPipeline.Producer do
 
   use GenStage
 
-  def init(_opts) do
-    {:producer, %{jobs: []}}
+  @impl true
+  def init(opts) do
+    buffer_size = Keyword.get(opts, :buffer_size, :infinity)
+
+    {:producer, %{jobs: []}, buffer_size: buffer_size}
   end
 
+  @impl true
   def handle_demand(demand, %{jobs: jobs} = state) do
     {dispatch_jobs, remaing_jobs} = Enum.split(jobs, demand)
 

--- a/test/faktory_worker/push_pipeline/producer_test.exs
+++ b/test/faktory_worker/push_pipeline/producer_test.exs
@@ -1,0 +1,21 @@
+defmodule FaktoryWorker.PushPipeline.ProducerTest do
+  use ExUnit.Case
+
+  alias FaktoryWorker.PushPipeline.Producer
+
+  describe "init/1" do
+    test "should return with default values" do
+      {type, state, opts} = Producer.init([])
+
+      assert type == :producer
+      assert state == %{jobs: []}
+      assert opts == [buffer_size: :infinity]
+    end
+
+    test "should return with configured buffer size" do
+      {:producer, _, opts} = Producer.init(buffer_size: 5000)
+
+      assert opts == [buffer_size: 5000]
+    end
+  end
+end


### PR DESCRIPTION
Updates the producer to default to an infinite buffer size to prevent discarding messages under load.

This can be configured via the pool config and set to any positive integer like so.

```elixir
{FaktoryWorker, pool: [buffer_size: 20_000], workers: [..]}
```