### PR TITLE
Remove the perform callback

### DIFF
--- a/lib/faktory_worker/job.ex
+++ b/lib/faktory_worker/job.ex
@@ -5,8 +5,6 @@ defmodule FaktoryWorker.Job do
 
   alias FaktoryWorker.Random
 
-  @callback perform(args :: any()) :: any()
-
   # Look at supporting the following optional fields when pushing a job
   # priority
   # at


### PR DESCRIPTION
The perform callback has been removed since we don't know the arity of the perform function at compile time since this is determined by the number of arguments in the faktory job.

I have merged this since there are no functional changes but we should have a chat about whether the perform function should be dynamic or have a fixed arity.