### PR TITLE
Do not recv on a socket after sending END

### DIFF
--- a/lib/faktory_worker/connection_manager.ex
+++ b/lib/faktory_worker/connection_manager.ex
@@ -49,17 +49,12 @@ defmodule FaktoryWorker.ConnectionManager do
 
         {{:ok, reason}, state}
 
+      {{:ok, :closed}, state} ->
+        {{:ok, :closed}, %{state | conn: nil}}
+
       result ->
         result
     end
-  end
-
-  @spec close_connection(state :: ConnectionManager.t()) :: ConnectionManager.t()
-  def close_connection(%{conn: nil} = state), do: state
-
-  def close_connection(%{conn: conn} = state) do
-    {:ok, _} = Connection.close(conn)
-    %{state | conn: nil}
   end
 
   defp try_send_command(%{conn: nil, opts: opts} = state, command) do

--- a/lib/faktory_worker/socket.ex
+++ b/lib/faktory_worker/socket.ex
@@ -6,8 +6,6 @@ defmodule FaktoryWorker.Socket do
   @callback connect(host :: String.t(), port :: pos_integer(), opts :: keyword()) ::
               {:ok, Connection.t()} | {:error, term()}
 
-  @callback close(connection :: Connection.t()) :: :ok
-
   @callback send(connection :: Connection.t(), payload :: String.t()) ::
               :ok | {:error, term()}
 

--- a/lib/faktory_worker/socket/ssl.ex
+++ b/lib/faktory_worker/socket/ssl.ex
@@ -13,11 +13,6 @@ defmodule FaktoryWorker.Socket.Ssl do
   end
 
   @impl true
-  def close(%{socket: socket}) do
-    :ssl.close(socket)
-  end
-
-  @impl true
   def send(%{socket: socket}, payload) do
     :ssl.send(socket, payload)
   end

--- a/lib/faktory_worker/socket/tcp.ex
+++ b/lib/faktory_worker/socket/tcp.ex
@@ -13,11 +13,6 @@ defmodule FaktoryWorker.Socket.Tcp do
   end
 
   @impl true
-  def close(%{socket: socket}) do
-    :gen_tcp.close(socket)
-  end
-
-  @impl true
   def send(%{socket: socket}, payload) do
     :gen_tcp.send(socket, payload)
   end

--- a/lib/faktory_worker/worker.ex
+++ b/lib/faktory_worker/worker.ex
@@ -151,8 +151,7 @@ defmodule FaktoryWorker.Worker do
     %{state | conn: conn, beat_state: :error}
   end
 
-  defp handle_end_response({_, conn}, state) do
-    %{conn: nil} = ConnectionManager.close_connection(conn)
+  defp handle_end_response({{:ok, :closed}, _}, state) do
     %{state | worker_state: :ended, conn: nil}
   end
 

--- a/test/faktory_worker/connection/socket/ssl_test.exs
+++ b/test/faktory_worker/connection/socket/ssl_test.exs
@@ -27,18 +27,6 @@ defmodule FaktoryWorker.Connection.Socket.SslTest do
     end
   end
 
-  describe "close/1" do
-    test "should close a socket connection to faktory" do
-      opts = [tls_verify: false]
-      {:ok, %Connection{} = connection} = Ssl.connect(@tls_host, @tls_port, opts)
-
-      :ok = Ssl.close(connection)
-      {:sslsocket, {:gen_tcp, socket, _, _}, _} = connection.socket
-
-      assert :erlang.port_info(socket) == :undefined
-    end
-  end
-
   describe "send/1" do
     test "should be able to send a packet to faktory" do
       opts = [tls_verify: false]

--- a/test/faktory_worker/connection/socket/tcp_test.exs
+++ b/test/faktory_worker/connection/socket/tcp_test.exs
@@ -21,16 +21,6 @@ defmodule FaktoryWorker.Connection.Socket.TcpTest do
     end
   end
 
-  describe "close/1" do
-    test "should close a socket connection to faktory" do
-      {:ok, %Connection{} = connection} = Tcp.connect("localhost", 7419)
-
-      :ok = Tcp.close(connection)
-
-      assert :erlang.port_info(connection.socket) == :undefined
-    end
-  end
-
   describe "send/1" do
     test "should be able to send a packet to faktory" do
       {:ok, %Connection{} = connection} = Tcp.connect("localhost", 7419)

--- a/test/faktory_worker/worker_test.exs
+++ b/test/faktory_worker/worker_test.exs
@@ -291,14 +291,6 @@ defmodule FaktoryWorker.WorkerTest do
         :ok
       end)
 
-      expect(FaktoryWorker.SocketMock, :recv, fn _ ->
-        {:ok, "+OK\r\n"}
-      end)
-
-      expect(FaktoryWorker.SocketMock, :close, fn _ ->
-        :ok
-      end)
-
       opts = [
         worker_id: Random.worker_id(),
         worker_module: TestQueueWorker,

--- a/test/support/connection_helpers.ex
+++ b/test/support/connection_helpers.ex
@@ -70,16 +70,8 @@ defmodule FaktoryWorker.ConnectionHelpers do
 
   defmacro connection_close_mox() do
     quote do
-      expect(FaktoryWorker.SocketMock, :close, fn _ ->
-        :ok
-      end)
-
       expect(FaktoryWorker.SocketMock, :send, fn _, "END\r\n" ->
         :ok
-      end)
-
-      expect(FaktoryWorker.SocketMock, :recv, fn _ ->
-        {:ok, "+OK\r\n"}
       end)
     end
   end


### PR DESCRIPTION
Update the connection module to prevent calling `recv/1` after sending the `END` command. This also removes the `close` function from the socket behaviour since this is no longer needed.

Fixes #51 