### PR TITLE
Update connection server to handle ssl errors

### DIFF
--- a/lib/faktory_worker/connection.ex
+++ b/lib/faktory_worker/connection.ex
@@ -9,6 +9,8 @@ defmodule FaktoryWorker.Connection do
 
   @type t :: %__MODULE__{}
 
+  @type response :: Protocol.protocol_response() | {:ok, :closed}
+
   @enforce_keys [:host, :port, :socket, :socket_handler]
   defstruct [:host, :port, :socket, :socket_handler]
 
@@ -25,8 +27,7 @@ defmodule FaktoryWorker.Connection do
     end
   end
 
-  @spec send_command(connection :: __MODULE__.t(), Protocol.protocol_command()) ::
-          Protocol.protocol_response() | {:ok, :closed}
+  @spec send_command(connection :: __MODULE__.t(), Protocol.protocol_command()) :: response()
   def send_command(%{socket_handler: socket_handler} = connection, :end) do
     with {:ok, payload} <- Protocol.encode_command(:end),
          :ok <- socket_handler.send(connection, payload) do

--- a/lib/faktory_worker/connection_manager.ex
+++ b/lib/faktory_worker/connection_manager.ex
@@ -29,7 +29,7 @@ defmodule FaktoryWorker.ConnectionManager do
           command :: FaktoryWorker.Protocol.protocol_command(),
           allow_retry :: boolean()
         ) ::
-          {Protocol.protocol_response(), ConnectionManager.t()}
+          {Connection.response(), ConnectionManager.t()}
   def send_command(state, command, allow_retry \\ true) do
     case try_send_command(state, command) do
       {{:error, reason}, _} when reason in @connection_errors ->

--- a/lib/faktory_worker/connection_manager/server.ex
+++ b/lib/faktory_worker/connection_manager/server.ex
@@ -29,7 +29,6 @@ defmodule FaktoryWorker.ConnectionManager.Server do
 
   @impl true
   def handle_info({:ssl_closed, _}, state) do
-    state = %{state | conn: nil}
-    {:noreply, state}
+    {:stop, :normal, %{state | conn: nil}}
   end
 end

--- a/lib/faktory_worker/connection_manager/server.ex
+++ b/lib/faktory_worker/connection_manager/server.ex
@@ -26,4 +26,10 @@ defmodule FaktoryWorker.ConnectionManager.Server do
     {result, state} = ConnectionManager.send_command(state, command)
     {:reply, result, state}
   end
+
+  @impl true
+  def handle_info({:ssl_closed, _}, state) do
+    state = %{state | conn: nil}
+    {:noreply, state}
+  end
 end

--- a/lib/faktory_worker/connection_manager/server.ex
+++ b/lib/faktory_worker/connection_manager/server.ex
@@ -11,7 +11,7 @@ defmodule FaktoryWorker.ConnectionManager.Server do
   end
 
   @spec send_command(connection_manager :: atom() | pid(), command :: Protocol.protocol_command()) ::
-          {:ok, any()} | {:error, any()}
+          FaktoryWorker.Connection.response()
   def send_command(connection_manager, command) do
     GenServer.call(connection_manager, {:send_command, command})
   end

--- a/lib/faktory_worker/worker.ex
+++ b/lib/faktory_worker/worker.ex
@@ -62,10 +62,16 @@ defmodule FaktoryWorker.Worker do
   end
 
   @spec send_end(state :: __MODULE__.t()) :: __MODULE__.t()
-  def send_end(%{conn_pid: conn_pid} = state) do
-    conn_pid
-    |> send_command(:end)
-    |> handle_end_response(state)
+  def send_end(%{conn_pid: conn_pid} = state) when is_pid(conn_pid) do
+    # only attempt to send the end command if there is a chance
+    # the connection is still available
+    if Process.alive?(conn_pid) do
+      conn_pid
+      |> send_command(:end)
+      |> handle_end_response(state)
+    else
+      handle_end_response({:ok, :closed}, state)
+    end
   end
 
   def send_end(state), do: state

--- a/lib/faktory_worker/worker/server.ex
+++ b/lib/faktory_worker/worker/server.ex
@@ -63,6 +63,10 @@ defmodule FaktoryWorker.Worker.Server do
     {:noreply, state}
   end
 
+  def handle_info({:EXIT, conn_pid, _reason}, %{conn_pid: conn_pid} = state) do
+    {:stop, :normal, %{state | conn_pid: nil}}
+  end
+
   @impl true
   def terminate(_reason, state) do
     Worker.send_end(state)

--- a/test/faktory_worker/connection/connection_test.exs
+++ b/test/faktory_worker/connection/connection_test.exs
@@ -186,7 +186,7 @@ defmodule FaktoryWorker.Connection.ConnectionTest do
       assert reason == "Something went wrong"
     end
 
-    test "should not call not call recv function when sending an END command" do
+    test "should not call recv function when sending an END command" do
       connection_mox()
 
       expect(FaktoryWorker.SocketMock, :send, fn _, "END\r\n" ->

--- a/test/faktory_worker/connection_manager/server_test.exs
+++ b/test/faktory_worker/connection_manager/server_test.exs
@@ -10,7 +10,7 @@ defmodule FaktoryWorker.ConnectionManager.ServerTest do
 
   describe "handle_info/2" do
     test "should handle the ssl_closed error message" do
-      # the nil values in this error are replaceing implementation details in the :ssl module
+      # the nil values in this error are replacing implementation details in the :ssl module
       # and are not used by the server
       error =
         {:ssl_closed, {:sslsocket, {:gen_tcp, nil, :tls_connection, :undefined}, [nil, nil]}}

--- a/test/faktory_worker/connection_manager/server_test.exs
+++ b/test/faktory_worker/connection_manager/server_test.exs
@@ -1,0 +1,32 @@
+defmodule FaktoryWorker.ConnectionManager.ServerTest do
+  use ExUnit.Case
+
+  import Mox
+
+  alias FaktoryWorker.ConnectionManager.Server
+
+  setup :set_mox_global
+  setup :verify_on_exit!
+
+  describe "handle_info/2" do
+    test "should handle the ssl_closed error message" do
+      # the nil values in this error are replaceing implementation details in the :ssl module
+      # and are not used by the server
+      error =
+        {:ssl_closed, {:sslsocket, {:gen_tcp, nil, :tls_connection, :undefined}, [nil, nil]}}
+
+      state = %FaktoryWorker.ConnectionManager{
+        conn: %FaktoryWorker.Connection{
+          host: "localhost",
+          port: 7419,
+          socket: :fake_socket,
+          socket_handler: FaktoryWorker.Socket.Ssl
+        }
+      }
+
+      {:noreply, new_state} = Server.handle_info(error, state)
+
+      assert new_state.conn == nil
+    end
+  end
+end

--- a/test/faktory_worker/connection_manager/server_test.exs
+++ b/test/faktory_worker/connection_manager/server_test.exs
@@ -24,7 +24,7 @@ defmodule FaktoryWorker.ConnectionManager.ServerTest do
         }
       }
 
-      {:noreply, new_state} = Server.handle_info(error, state)
+      {:stop, :normal, new_state} = Server.handle_info(error, state)
 
       assert new_state.conn == nil
     end

--- a/test/faktory_worker/worker/server_integration_test.exs
+++ b/test/faktory_worker/worker/server_integration_test.exs
@@ -20,12 +20,14 @@ defmodule FaktoryWorker.Worker.ServerIntegrationTest do
 
       pid = start_supervised!(Server.child_spec(opts))
 
-      %{conn: connection_manager} = :sys.get_state(pid)
+      %{conn_pid: conn_pid} = :sys.get_state(pid)
 
-      assert connection_manager.conn.host == "localhost"
-      assert connection_manager.conn.port == 7419
-      assert connection_manager.conn.socket_handler == FaktoryWorker.Socket.Tcp
-      assert is_port(connection_manager.conn.socket)
+      state = :sys.get_state(conn_pid)
+
+      assert state.conn.host == "localhost"
+      assert state.conn.port == 7419
+      assert state.conn.socket_handler == FaktoryWorker.Socket.Tcp
+      assert is_port(state.conn.socket)
 
       :ok = stop_supervised(:test_worker_1)
     end

--- a/test/faktory_worker/worker/server_test.exs
+++ b/test/faktory_worker/worker/server_test.exs
@@ -75,6 +75,25 @@ defmodule FaktoryWorker.Worker.ServerTest do
     end
   end
 
+  describe "handle_info/2" do
+    test "should handle the connection process exiting and stop the worker" do
+      worker_connection_mox()
+
+      opts = [
+        worker_id: Random.worker_id(),
+        worker_module: TestQueueWorker,
+        connection: [socket_handler: FaktoryWorker.SocketMock]
+      ]
+
+      pid = start_supervised!(Server.child_spec(opts))
+      state = :sys.get_state(pid)
+
+      {:stop, :normal, state} = Server.handle_info({:EXIT, state.conn_pid, :shutdown}, state)
+
+      assert state.conn_pid == nil
+    end
+  end
+
   describe "termiante/2" do
     test "should send the 'END' command when the server terminates" do
       worker_connection_mox()

--- a/test/faktory_worker/worker/server_test.exs
+++ b/test/faktory_worker/worker/server_test.exs
@@ -62,12 +62,14 @@ defmodule FaktoryWorker.Worker.ServerTest do
 
       pid = start_supervised!(Server.child_spec(opts))
 
-      %{conn: connection_manager} = :sys.get_state(pid)
+      %{conn_pid: conn_pid} = :sys.get_state(pid)
 
-      assert connection_manager.conn.host == "localhost"
-      assert connection_manager.conn.port == 7419
-      assert connection_manager.conn.socket_handler == FaktoryWorker.SocketMock
-      assert connection_manager.conn.socket == :test_socket
+      state = :sys.get_state(conn_pid)
+
+      assert state.conn.host == "localhost"
+      assert state.conn.port == 7419
+      assert state.conn.socket_handler == FaktoryWorker.SocketMock
+      assert state.conn.socket == :test_socket
 
       :ok = stop_supervised(:test_worker_1)
     end

--- a/test/faktory_worker/worker_test.exs
+++ b/test/faktory_worker/worker_test.exs
@@ -1,5 +1,5 @@
 defmodule FaktoryWorker.WorkerTest do
-  use ExUnit.Case, async: true
+  use ExUnit.Case
 
   import Mox
   import FaktoryWorker.ConnectionHelpers
@@ -11,6 +11,7 @@ defmodule FaktoryWorker.WorkerTest do
 
   @fifteen_seconds 15_000
 
+  setup :set_mox_global
   setup :verify_on_exit!
 
   describe "new/2" do
@@ -54,7 +55,7 @@ defmodule FaktoryWorker.WorkerTest do
 
       worker = Worker.new(opts)
 
-      assert worker.conn != nil
+      assert is_pid(worker.conn_pid)
     end
 
     test "should schedule a beat to be triggered" do
@@ -302,7 +303,7 @@ defmodule FaktoryWorker.WorkerTest do
         |> Worker.new()
         |> Worker.send_end()
 
-      assert result.conn == nil
+      assert result.conn_pid == nil
       assert result.worker_state == :ended
     end
 


### PR DESCRIPTION
Adds ssl error handling to the `ConnectionManager.Server` and updates the worker module to use this server in order to isolate it from tcp concerns.

Fixes #48