### PR TITLE
Optimize worker shutdown performance

### DIFF
--- a/lib/faktory_worker/worker/pool.ex
+++ b/lib/faktory_worker/worker/pool.ex
@@ -1,0 +1,48 @@
+defmodule FaktoryWorker.Worker.Pool do
+  use Supervisor
+
+  alias FaktoryWorker.Random
+
+  @spec start_link(opts :: keyword()) :: Supervisor.on_start()
+  def start_link(opts) do
+    Supervisor.start_link(__MODULE__, opts, name: format_worker_pool_name(opts))
+  end
+
+  @impl true
+  def init(opts) do
+    children =
+      opts
+      |> Keyword.get(:workers, [])
+      |> Enum.map(&map_worker(&1, opts))
+      |> List.flatten()
+
+    Supervisor.init(children, strategy: :one_for_one)
+  end
+
+  defp map_worker(worker_module, opts) do
+    connection_opts = Keyword.get(opts, :connection, [])
+    worker_opts = worker_module.worker_config()
+    concurrency = Keyword.get(worker_opts, :concurrency, 1)
+    disable_fetch = Keyword.get(worker_opts, :disable_fetch, false)
+
+    Enum.reduce(1..concurrency, [], fn _, acc ->
+      worker_id = Random.worker_id()
+      worker_name = :"#{worker_module}_#{worker_id}"
+
+      opts = [
+        name: worker_name,
+        connection: connection_opts,
+        worker_id: worker_id,
+        worker_module: worker_module,
+        disable_fetch: disable_fetch
+      ]
+
+      [FaktoryWorker.Worker.Server.child_spec(opts) | acc]
+    end)
+  end
+
+  def format_worker_pool_name(opts) do
+    name = Keyword.get(opts, :name)
+    :"#{name}_worker_pool"
+  end
+end

--- a/lib/faktory_worker/worker/server.ex
+++ b/lib/faktory_worker/worker/server.ex
@@ -19,6 +19,11 @@ defmodule FaktoryWorker.Worker.Server do
     }
   end
 
+  @spec disable_fetch(GenServer.server()) :: :ok
+  def disable_fetch(server) do
+    GenServer.cast(server, :disable_fetch)
+  end
+
   @impl true
   def init(opts) do
     Process.flag(:trap_exit, true)
@@ -29,6 +34,11 @@ defmodule FaktoryWorker.Worker.Server do
   def handle_continue({:setup_connection, opts}, _) do
     worker = Worker.new(opts)
     {:noreply, worker}
+  end
+
+  @impl true
+  def handle_cast(:disable_fetch, state) do
+    {:noreply, %{state | disable_fetch: true}}
   end
 
   @impl true

--- a/lib/faktory_worker/worker/shutdown_server.ex
+++ b/lib/faktory_worker/worker/shutdown_server.ex
@@ -1,0 +1,44 @@
+defmodule FaktoryWorker.Worker.ShutdownManager do
+  @moduledoc false
+
+  use GenServer
+
+  alias FaktoryWorker.Worker.Server
+
+  @spec start_link(opts :: keyword()) :: Supervisor.on_start()
+  def start_link(opts) do
+    GenServer.start_link(__MODULE__, opts, name: name_from_opts(opts))
+  end
+
+  @spec child_spec(opts :: keyword()) :: Supervisor.child_spec()
+  def child_spec(opts) do
+    %{
+      id: name_from_opts(opts),
+      start: {__MODULE__, :start_link, [opts]},
+      type: :worker
+    }
+  end
+
+  @impl true
+  def init(opts) do
+    Process.flag(:trap_exit, true)
+    {:ok, opts}
+  end
+
+  @impl true
+  def terminate(_reason, state) do
+    state
+    |> FaktoryWorker.Worker.Pool.format_worker_pool_name()
+    |> Supervisor.which_children()
+    |> Enum.each(&shutdown_worker/1)
+  end
+
+  defp shutdown_worker({_, worker_pid, _, _}) do
+    Server.disable_fetch(worker_pid)
+  end
+
+  defp name_from_opts(opts) do
+    name = Keyword.get(opts, :name, __MODULE__)
+    :"#{name}_shutdown_manager"
+  end
+end

--- a/lib/faktory_worker/worker_supervisor.ex
+++ b/lib/faktory_worker/worker_supervisor.ex
@@ -3,8 +3,6 @@ defmodule FaktoryWorker.WorkerSupervisor do
 
   use Supervisor
 
-  alias FaktoryWorker.Random
-
   @spec start_link(opts :: keyword()) :: Supervisor.on_start()
   def start_link(opts) do
     name = Keyword.get(opts, :name)
@@ -13,34 +11,11 @@ defmodule FaktoryWorker.WorkerSupervisor do
 
   @impl true
   def init(opts) do
-    children =
-      opts
-      |> Keyword.get(:workers, [])
-      |> Enum.map(&map_worker(&1, opts))
-      |> List.flatten()
+    children = [
+      {FaktoryWorker.Worker.Pool, opts},
+      {FaktoryWorker.Worker.ShutdownManager, opts}
+    ]
 
     Supervisor.init(children, strategy: :one_for_one)
-  end
-
-  defp map_worker(worker_module, opts) do
-    connection_opts = Keyword.get(opts, :connection, [])
-    worker_opts = worker_module.worker_config()
-    concurrency = Keyword.get(worker_opts, :concurrency, 1)
-    disable_fetch = Keyword.get(worker_opts, :disable_fetch, false)
-
-    Enum.reduce(1..concurrency, [], fn _, acc ->
-      worker_id = Random.worker_id()
-      worker_name = :"#{worker_module}_#{worker_id}"
-
-      opts = [
-        name: worker_name,
-        connection: connection_opts,
-        worker_id: worker_id,
-        worker_module: worker_module,
-        disable_fetch: disable_fetch
-      ]
-
-      [FaktoryWorker.Worker.Server.child_spec(opts) | acc]
-    end)
   end
 end

--- a/test/faktory_worker/worker/pool_test.exs
+++ b/test/faktory_worker/worker/pool_test.exs
@@ -1,0 +1,86 @@
+defmodule FaktoryWorker.Worker.PoolTest do
+  use ExUnit.Case
+
+  alias FaktoryWorker.Worker.Pool
+
+  defmodule SingleWorker do
+    use FaktoryWorker.Job,
+      disable_fetch: true
+
+    def perform(_), do: :ok
+  end
+
+  defmodule MultiWorker do
+    use FaktoryWorker.Job,
+      disable_fetch: true,
+      concurrency: 10
+
+    def perform(_), do: :ok
+  end
+
+  describe "start_link/1" do
+    test "should start the supervisor" do
+      opts = [name: FaktoryWorker]
+
+      {:ok, pid} = Pool.start_link(opts)
+
+      assert pid == Process.whereis(FaktoryWorker_worker_pool)
+
+      :ok = Supervisor.stop(pid)
+    end
+
+    test "should start the list of specified workers" do
+      opts = [name: FaktoryWorker, workers: [SingleWorker]]
+      {:ok, pid} = Pool.start_link(opts)
+
+      [{worker_name, _, type, [server_module]}] = Supervisor.which_children(pid)
+      [worker_name, worker_id] = split_worker_name(worker_name)
+
+      assert worker_name == "SingleWorker"
+      assert byte_size(worker_id) == 16
+      assert type == :worker
+      assert server_module == FaktoryWorker.Worker.Server
+
+      :ok = Supervisor.stop(pid)
+    end
+
+    test "should start the list of specified workers with concurrency settings" do
+      opts = [name: FaktoryWorker, workers: [SingleWorker, MultiWorker]]
+      {:ok, pid} = Pool.start_link(opts)
+      children = Supervisor.which_children(pid)
+
+      %{"SingleWorker" => single_workers, "MultiWorker" => multi_workers} =
+        children
+        |> Enum.group_by(
+          fn {worker_name, _, _, _} ->
+            worker_name
+            |> split_worker_name()
+            |> List.first()
+          end,
+          fn {worker_name, _, _, _} ->
+            worker_name
+            |> split_worker_name()
+            |> List.last()
+          end
+        )
+
+      assert length(children) == 11
+      assert length(single_workers) == 1
+      assert length(multi_workers) == 10
+
+      :ok = Supervisor.stop(pid)
+    end
+  end
+
+  describe "format_worker_pool_name/1" do
+    test "should return the pool name" do
+      name = Pool.format_worker_pool_name(name: :test)
+      assert name == :test_worker_pool
+    end
+  end
+
+  defp split_worker_name(worker_name) do
+    [_, _, _, worker_name] = Module.split(worker_name)
+    String.split(worker_name, "_")
+  end
+end

--- a/test/faktory_worker/worker/server_test.exs
+++ b/test/faktory_worker/worker/server_test.exs
@@ -75,6 +75,22 @@ defmodule FaktoryWorker.Worker.ServerTest do
     end
   end
 
+  describe "disable_fetch/1" do
+    test "should cast the disable fetch message" do
+      Server.disable_fetch(self())
+      assert_receive {:"$gen_cast", :disable_fetch}, 50
+    end
+  end
+
+  describe "handle_cast/2" do
+    test "should handle the disable fetch message" do
+      state = %{disable_fetch: false}
+      {:noreply, new_state} = Server.handle_cast(:disable_fetch, state)
+
+      assert new_state.disable_fetch == true
+    end
+  end
+
   describe "handle_info/2" do
     test "should handle the connection process exiting and stop the worker" do
       worker_connection_mox()

--- a/test/faktory_worker/worker/shutdown_server_test.exs
+++ b/test/faktory_worker/worker/shutdown_server_test.exs
@@ -1,0 +1,21 @@
+defmodule FaktoryWorker.Worker.ShutdownServerTest do
+  use ExUnit.Case
+
+  alias FaktoryWorker.Worker.ShutdownManager
+
+  describe "start_link2" do
+    test "should start the supervisor" do
+      opts = [name: FaktoryWorker]
+
+      # need to start a pool to prevent error when
+      # terminating the shutdown server
+      start_supervised!({FaktoryWorker.Worker.Pool, opts})
+
+      {:ok, pid} = ShutdownManager.start_link(opts)
+
+      assert pid == Process.whereis(FaktoryWorker_shutdown_manager)
+
+      :ok = Supervisor.stop(pid)
+    end
+  end
+end

--- a/test/faktory_worker/worker_supervisor_test.exs
+++ b/test/faktory_worker/worker_supervisor_test.exs
@@ -3,21 +3,6 @@ defmodule FaktoryWorker.WorkerSupervisorTest do
 
   alias FaktoryWorker.WorkerSupervisor
 
-  defmodule SingleWorker do
-    use FaktoryWorker.Job,
-      disable_fetch: true
-
-    def perform(_), do: :ok
-  end
-
-  defmodule MultiWorker do
-    use FaktoryWorker.Job,
-      disable_fetch: true,
-      concurrency: 10
-
-    def perform(_), do: :ok
-  end
-
   describe "start_link/1" do
     test "should start the supervisor" do
       opts = [name: FaktoryWorker]
@@ -29,51 +14,21 @@ defmodule FaktoryWorker.WorkerSupervisorTest do
       :ok = Supervisor.stop(pid)
     end
 
-    test "should start the list of specified workers" do
-      opts = [name: FaktoryWorker, workers: [SingleWorker]]
+    test "should start children" do
+      opts = [name: FaktoryWorker]
+
       {:ok, pid} = WorkerSupervisor.start_link(opts)
 
-      [{worker_name, _, type, [server_module]}] = Supervisor.which_children(pid)
-      [worker_name, worker_id] = split_worker_name(worker_name)
-
-      assert worker_name == "SingleWorker"
-      assert byte_size(worker_id) == 16
-      assert type == :worker
-      assert server_module == FaktoryWorker.Worker.Server
-
-      :ok = Supervisor.stop(pid)
-    end
-
-    test "should start the list of specified workers with concurrency settings" do
-      opts = [name: FaktoryWorker, workers: [SingleWorker, MultiWorker]]
-      {:ok, pid} = WorkerSupervisor.start_link(opts)
       children = Supervisor.which_children(pid)
 
-      %{"SingleWorker" => single_workers, "MultiWorker" => multi_workers} =
-        children
-        |> Enum.group_by(
-          fn {worker_name, _, _, _} ->
-            worker_name
-            |> split_worker_name()
-            |> List.first()
-          end,
-          fn {worker_name, _, _, _} ->
-            worker_name
-            |> split_worker_name()
-            |> List.last()
-          end
-        )
+      [shutdown_manager, pool] = children
 
-      assert length(children) == 11
-      assert length(single_workers) == 1
-      assert length(multi_workers) == 10
+      assert {FaktoryWorker_shutdown_manager, _, :worker, [FaktoryWorker.Worker.ShutdownManager]} =
+               shutdown_manager
+
+      assert {FaktoryWorker.Worker.Pool, _, :supervisor, [FaktoryWorker.Worker.Pool]} = pool
 
       :ok = Supervisor.stop(pid)
     end
-  end
-
-  defp split_worker_name(worker_name) do
-    [_, _, worker_name] = Module.split(worker_name)
-    String.split(worker_name, "_")
   end
 end


### PR DESCRIPTION
Adds a new `ShutdownManager` server to the worker supervision tree that disables fetching on the workers in the tree to allow for faster shutdown.

Because OTP shuts down the workers synchronously the issue with slow shutdowns was caused by each worker waiting up to 2 seconds to finish the fetch request to faktory. We now use the shutdown manager to detect a shutdown (it gets shutdown before workers) and iterate through each of the workers disabling fetch. This allows the worker some time to complete the current request and get shutdown gracefully by the pool supervisor.