### PR TITLE
Encode args when pushing jobs to faktory

### DIFF
--- a/test/faktory_worker/job/job_integration_test.exs
+++ b/test/faktory_worker/job/job_integration_test.exs
@@ -16,7 +16,8 @@ defmodule FaktoryWorker.JobIntegrationTest do
 
       opts = [faktory_name: faktory_name]
 
-      job = Job.build_payload(DefaultWorker, %{hey: "there!"}, opts)
+      {:ok, data} = Job.encode_job(%{hey: "there!"})
+      job = Job.build_payload(DefaultWorker, data, opts)
 
       Job.perform_async(job, opts)
 

--- a/test/faktory_worker/push_pipeline/acknowledger_integration_test.exs
+++ b/test/faktory_worker/push_pipeline/acknowledger_integration_test.exs
@@ -15,7 +15,7 @@ defmodule FaktoryWorker.PushPipeline.AcknowledgerIntegrationTest do
       faktory_name = :"Test_#{Random.string()}"
       pipeline_name = FaktoryWorker.PushPipeline.format_pipeline_name(faktory_name)
 
-      job = %{hey: "there!"}
+      {:ok, job} = Job.encode_job(%{hey: "there!"})
       opts = [faktory_name: faktory_name]
 
       payload1 = Job.build_payload(DefaultWorker, job, opts)


### PR DESCRIPTION
Make sure job args are encoded when being pushed to faktory.

WIP since there is one remaining test failure.