### PR TITLE
Support passing structs as job arguments

### DIFF
--- a/lib/faktory_worker/job.ex
+++ b/lib/faktory_worker/job.ex
@@ -40,7 +40,7 @@ defmodule FaktoryWorker.Job do
     %{
       jid: Random.job_id(),
       jobtype: job_type_for_module(worker_module),
-      args: job
+      args: normalize_job_args(job)
     }
     |> append_optional_fields(opts)
   end
@@ -101,5 +101,15 @@ defmodule FaktoryWorker.Job do
     module
     |> to_string()
     |> String.trim_leading("Elixir.")
+  end
+
+  defp normalize_job_args(job) do
+    Enum.map(job, fn
+      %_{} = arg ->
+        Map.from_struct(arg)
+
+      arg ->
+        arg
+    end)
   end
 end

--- a/test/faktory_worker/job/job_test.exs
+++ b/test/faktory_worker/job/job_test.exs
@@ -22,6 +22,8 @@ defmodule FaktoryWorker.Job.JobTest do
     def perform(_), do: :ok
   end
 
+  defstruct [:value]
+
   describe "build_payload/3" do
     test "should create new faktory job struct" do
       data = %{hey: "there!"}
@@ -48,6 +50,15 @@ defmodule FaktoryWorker.Job.JobTest do
       assert job.jid != nil
       assert job.jobtype == "Test.Worker"
       assert job.args == [data]
+    end
+
+    test "should be able to pass in a struct as a job arg" do
+      data = %__MODULE__{value: "hey there!"}
+      job = Job.build_payload(Test.Worker, data, [])
+
+      assert job.jid != nil
+      assert job.jobtype == "Test.Worker"
+      assert job.args == [%{value: "hey there!"}]
     end
 
     test "should be able to specify a queue name" do


### PR DESCRIPTION
Currently when serialising job arguments containing a struct we return an error stating the argument cannot be serialised. This is because the `Jason` library does not support encoding structs unless an encoder protocol has been implemented for it.

This PR adds support for passing structs by converting them into a map since we do not need to persist the struct type when sending and receiving from faktory. If this is required at some point (i.e. the worker `perform` function is matching on it) in the future we may have to look at allowing an encoder to be configured for a job or look at supporting this generically.