### PR TITLE
Add support for -NOTUNIQUE error response

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -45,11 +45,11 @@ workflows:
   build:
     jobs:
       - build:
-          faktory_version: "0.9.6"
-          name: "0.9.6"
+          faktory_version: "1.0.0"
+          name: "1.0.0"
       - build:
-          faktory_version: "0.9.7"
-          name: "0.9.7"
+          faktory_version: "1.0.1"
+          name: "1.0.1"
       - build:
           faktory_version: "latest"
           name: "latest"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,6 @@
 faktory_test:
   container_name: faktory_worker_test
-  image: contribsys/faktory:0.9.7
+  image: contribsys/faktory:1.0.1
   ports:
     - "7420:7420"
     - "7419:7419"
@@ -14,7 +14,7 @@ faktory_test_tls:
 
 faktory_password_test:
   container_name: faktory_worker_password_test
-  image: contribsys/faktory:0.9.7
+  image: contribsys/faktory:1.0.1
   ports:
     - "7620:7420"
     - "7619:7419"

--- a/lib/faktory_worker/connection_manager.ex
+++ b/lib/faktory_worker/connection_manager.ex
@@ -40,11 +40,8 @@ defmodule FaktoryWorker.ConnectionManager do
           do: send_command(%{state | conn: nil}, command, false),
           else: {error, state}
 
-      # Handle errors from Faktory that should not be tried again, such as
-      # unique jobs.
+      # Handle errors from Faktory that should not be tried again
       {{:error, "Halt: " <> reason = error}, state} ->
-        # when we add support for the -NOTUNIQUE response this logging
-        # should be moved into the WorkerLogger module
         log_error(error, command)
 
         {{:ok, reason}, state}

--- a/lib/faktory_worker/protocol.ex
+++ b/lib/faktory_worker/protocol.ex
@@ -71,6 +71,8 @@ defmodule FaktoryWorker.Protocol do
 
   def decode_response("-SHUTDOWN " <> rest), do: {:error, trim_newline(rest)}
 
+  def decode_response("-NOTUNIQUE " <> _), do: {:error, :not_unique}
+
   def decode_response("$-1\r\n"), do: {:ok, :no_content}
 
   def decode_response("$" <> rest) do

--- a/lib/faktory_worker/push_pipeline/acknowledger.ex
+++ b/lib/faktory_worker/push_pipeline/acknowledger.ex
@@ -2,15 +2,20 @@ defmodule FaktoryWorker.PushPipeline.Acknowledger do
   @moduledoc false
 
   alias FaktoryWorker.Job
+  alias FaktoryWorker.WorkerLogger
 
   @behaviour Broadway.Acknowledger
 
   @impl true
   def ack(_ack_ref, _successful_messages, failed_messages) do
-    Enum.each(failed_messages, fn %{data: {pipeline, payload}} ->
-      Job.perform_async(pipeline, payload, [])
-    end)
+    Enum.each(failed_messages, &handle_failed_message/1)
+  end
 
-    :ok
+  defp handle_failed_message(%{status: {:failed, :not_unique}, data: {_, job}}) do
+    WorkerLogger.log_not_unique_job(job.jid, job.args, job.jobtype)
+  end
+
+  defp handle_failed_message(%{data: {pipeline, payload}}) do
+    Job.perform_async(pipeline, payload, [])
   end
 end

--- a/lib/faktory_worker/worker_logger.ex
+++ b/lib/faktory_worker/worker_logger.ex
@@ -7,6 +7,12 @@ defmodule FaktoryWorker.WorkerLogger do
           :ok | {:error, any()}
   def log_push(jid, args, worker_module), do: log_info("Enqueued", jid, args, worker_module)
 
+  @spec log_not_unique_job(jid :: String.t(), args :: any(), worker_module :: String.t()) ::
+          :ok | {:error, any()}
+  def log_not_unique_job(jid, args, worker_module) do
+    log_info("NOTUNIQUE", jid, args, worker_module)
+  end
+
   @spec log_ack(:ok | :error, jid :: String.t(), args :: any(), worker_module :: String.t()) ::
           :ok | {:error, any()}
   def log_ack(:ok, jid, args, worker_module), do: log_info("Succeeded", jid, args, worker_module)

--- a/test/faktory_worker/protocol_test.exs
+++ b/test/faktory_worker/protocol_test.exs
@@ -88,39 +88,39 @@ defmodule FaktoryWorker.ProtocolTest do
 
   describe "decode_response/1" do
     test "should decode the 'HI' response" do
-      {:ok, resposne} = Protocol.decode_response("+HI {\"v\":2}\r\n")
+      {:ok, response} = Protocol.decode_response("+HI {\"v\":2}\r\n")
 
-      assert resposne == %{"v" => 2}
+      assert response == %{"v" => 2}
     end
 
     test "should decode the 'OK' response" do
-      {:ok, resposne} = Protocol.decode_response("+OK\r\n")
+      {:ok, response} = Protocol.decode_response("+OK\r\n")
 
-      assert resposne == "OK"
+      assert response == "OK"
     end
 
     test "should decode the '-ERR' response" do
-      {:error, resposne} = Protocol.decode_response("-ERR Some error\r\n")
+      {:error, response} = Protocol.decode_response("-ERR Some error\r\n")
 
-      assert resposne == "Some error"
+      assert response == "Some error"
     end
 
     test "should decode the '-SHUTDOWN' response" do
-      {:error, resposne} = Protocol.decode_response("-SHUTDOWN Shutdown in progress\r\n")
+      {:error, response} = Protocol.decode_response("-SHUTDOWN Shutdown in progress\r\n")
 
-      assert resposne == "Shutdown in progress"
+      assert response == "Shutdown in progress"
     end
 
     test "should decode the '$n' bulk string response" do
-      {:ok, resposne} = Protocol.decode_response("$592\r\n")
+      {:ok, response} = Protocol.decode_response("$592\r\n")
 
-      assert resposne == {:bulk_string, 594}
+      assert response == {:bulk_string, 594}
     end
 
     test "should decode a null bulk string response" do
-      {:ok, resposne} = Protocol.decode_response("$-1\r\n")
+      {:ok, response} = Protocol.decode_response("$-1\r\n")
 
-      assert resposne == :no_content
+      assert response == :no_content
     end
 
     test "should decode bulk string response" do
@@ -133,9 +133,15 @@ defmodule FaktoryWorker.ProtocolTest do
     end
 
     test "should decode a json hash response" do
-      {:ok, resposne} = Protocol.decode_response("+{\"hey\":\"there!\"}\r\n")
+      {:ok, response} = Protocol.decode_response("+{\"hey\":\"there!\"}\r\n")
 
-      assert resposne == %{"hey" => "there!"}
+      assert response == %{"hey" => "there!"}
+    end
+
+    test "should decode a -NOTUNIQUE response" do
+      {:error, response} = Protocol.decode_response("-NOTUNIQUE Job not unique\r\n")
+
+      assert response == :not_unique
     end
   end
 end

--- a/test/faktory_worker/push_pipeline/acknowledger_test.exs
+++ b/test/faktory_worker/push_pipeline/acknowledger_test.exs
@@ -1,0 +1,32 @@
+defmodule FaktoryWorker.PushPipeline.AcknowledgerTest do
+  use ExUnit.Case
+
+  import ExUnit.CaptureLog
+
+  alias FaktoryWorker.Random
+  alias FaktoryWorker.PushPipeline.Acknowledger
+
+  describe "ack/3" do
+    test "should log the not unique log message" do
+      jid = Random.job_id()
+
+      payload = %{
+        jid: jid,
+        args: ["some args"],
+        jobtype: "TestWorker"
+      }
+
+      failed_message = %{
+        status: {:failed, :not_unique},
+        data: {nil, payload}
+      }
+
+      log =
+        capture_log(fn ->
+          :ok = Acknowledger.ack(nil, [], [failed_message])
+        end)
+
+      assert log =~ "NOTUNIQUE (TestWorker) jid-#{jid} #{inspect(payload.args)}"
+    end
+  end
+end

--- a/test/faktory_worker/worker_logger_test.exs
+++ b/test/faktory_worker/worker_logger_test.exs
@@ -136,4 +136,20 @@ defmodule FaktoryWorker.WorkerLoggerTest do
                }"
     end
   end
+
+  describe "log_not_unique_job/2" do
+    test "should log a not unique job message" do
+      job_id = Random.job_id()
+      args = %{hey: "there!", custom: %{unique_for: 60}}
+      worker_module = "TestQueueWorker"
+
+      log_message =
+        capture_log(fn ->
+          WorkerLogger.log_not_unique_job(job_id, args, worker_module)
+        end)
+
+      assert log_message =~
+               "[faktory-worker] NOTUNIQUE (#{worker_module}) jid-#{job_id} #{inspect(args)}"
+    end
+  end
 end


### PR DESCRIPTION
Adds support for the `-NOTUNIQUE` error response returned by faktory when pushing a duplicate job.

When this response is received the result will be logged and the job will be discarded from the push pipeline.

The log entry will look like this.

`21:30:17.101 [info]  [faktory-worker] NOTUNIQUE (SomeWorker) jid-e76207f3fa8279be5fd6c2a6 ["job args"]`

This PR bring the minimum supported faktory version up to `1.0.0`.

Fixes #31 
Fixes #59 