### PR TITLE
Add support for specifying a concurrency limit per queue

### DIFF
--- a/lib/faktory_worker.ex
+++ b/lib/faktory_worker.ex
@@ -8,6 +8,7 @@ defmodule FaktoryWorker do
     opts = Keyword.put_new(opts, :name, __MODULE__)
 
     children = [
+      {FaktoryWorker.QueueManager, opts},
       {FaktoryWorker.Pool, opts},
       {FaktoryWorker.PushPipeline, opts},
       {FaktoryWorker.JobSupervisor, opts},

--- a/lib/faktory_worker/queue_manager.ex
+++ b/lib/faktory_worker/queue_manager.ex
@@ -1,0 +1,80 @@
+defmodule FaktoryWorker.QueueManager do
+  @moduledoc false
+
+  use Agent
+
+  defmodule Queue do
+    @enforce_keys [:name, :concurrency]
+    defstruct [:name, :concurrency]
+  end
+
+  def start_link(opts) do
+    name = opts[:name]
+    pool_opts = Keyword.get(opts, :worker_pool, [])
+    queues = Keyword.get(pool_opts, :queues, ["default"])
+    state = Enum.map(queues, &map_queues/1)
+
+    Agent.start_link(fn -> state end, name: format_queue_manager_name(name))
+  end
+
+  @spec checkout_queues(queue_manager_name :: atom()) :: list(String.t())
+  def checkout_queues(queue_manager_name) do
+    Agent.get_and_update(queue_manager_name, fn queues ->
+      queues
+      |> Enum.map_reduce([], &map_queue_to_fetch/2)
+      |> format_queues_to_fetch()
+    end)
+  end
+
+  @spec checkin_queues(queue_manager_name :: atom(), queues :: list(String.t())) :: :ok
+  def checkin_queues(queue_manager_name, queues) do
+    Agent.cast(queue_manager_name, fn state_queues ->
+      Enum.map(state_queues, &update_checkin_queues(&1, queues))
+    end)
+
+    :ok
+  end
+
+  @spec format_queue_manager_name(name :: atom()) :: atom()
+  def format_queue_manager_name(name) when is_atom(name) do
+    :"#{name}_queue_manager"
+  end
+
+  defp map_queues(queue) when is_binary(queue) do
+    %Queue{name: queue, concurrency: :infinity}
+  end
+
+  defp map_queues({queue, opts}) when is_binary(queue) do
+    concurrency = Keyword.get(opts, :concurrency, :infinity)
+    %Queue{name: queue, concurrency: concurrency}
+  end
+
+  defp map_queue_to_fetch(%{concurrency: :infinity} = queue, acc) do
+    {queue.name, [queue | acc]}
+  end
+
+  defp map_queue_to_fetch(%{concurrency: 0} = queue, acc) do
+    {nil, [queue | acc]}
+  end
+
+  defp map_queue_to_fetch(%{concurrency: concurrency} = queue, acc) when concurrency > 0 do
+    queue = %{queue | concurrency: concurrency - 1}
+    {queue.name, [queue | acc]}
+  end
+
+  defp update_checkin_queues(%{concurrency: :infinity} = queue, _), do: queue
+
+  defp update_checkin_queues(queue, checkin_queues) do
+    if Enum.member?(checkin_queues, queue.name) do
+      %{queue | concurrency: queue.concurrency + 1}
+    else
+      queue
+    end
+  end
+
+  defp format_queues_to_fetch({queues, state}) do
+    queues = Enum.reject(queues, &is_nil/1)
+    state = Enum.reverse(state)
+    {queues, state}
+  end
+end

--- a/lib/faktory_worker/worker/pool.ex
+++ b/lib/faktory_worker/worker/pool.ex
@@ -20,7 +20,6 @@ defmodule FaktoryWorker.Worker.Pool do
     connection_opts = Keyword.get(opts, :connection, [])
     process_wid = Keyword.get(opts, :process_wid)
     pool_opts = Keyword.get(opts, :worker_pool, [])
-    queues = Keyword.get(pool_opts, :queues, ["default"])
     disable_fetch = Keyword.get(pool_opts, :disable_fetch, false)
 
     opts = [
@@ -28,8 +27,7 @@ defmodule FaktoryWorker.Worker.Pool do
       faktory_name: Keyword.get(opts, :name),
       connection: connection_opts,
       process_wid: process_wid,
-      disable_fetch: disable_fetch,
-      queues: queues
+      disable_fetch: disable_fetch
     ]
 
     FaktoryWorker.Worker.Server.child_spec(opts)

--- a/lib/faktory_worker/worker/server.ex
+++ b/lib/faktory_worker/worker/server.ex
@@ -79,6 +79,11 @@ defmodule FaktoryWorker.Worker.Server do
     {:stop, :normal, %{state | conn_pid: nil}}
   end
 
+  @impl true
+  def terminate(_, state) do
+    Worker.checkin_queues(state)
+  end
+
   defp name_from_opts(opts) do
     Keyword.get(opts, :name, __MODULE__)
   end

--- a/test/faktory_worker/queue_manager_test.exs
+++ b/test/faktory_worker/queue_manager_test.exs
@@ -17,7 +17,7 @@ defmodule FaktoryWorker.QueueManagerTest do
     test "should set the queues state" do
       opts = [
         name: FaktoryWorker,
-        worker_pool: [queues: ["test1", {"test2", concurrency: 5}, "test3"]]
+        worker_pool: [queues: ["test1", {"test2", max_concurrency: 5}, "test3"]]
       ]
 
       {:ok, pid} = QueueManager.start_link(opts)
@@ -25,9 +25,9 @@ defmodule FaktoryWorker.QueueManagerTest do
       state = :sys.get_state(pid)
 
       assert state == [
-               %QueueManager.Queue{name: "test1", concurrency: :infinity},
-               %QueueManager.Queue{name: "test2", concurrency: 5},
-               %QueueManager.Queue{name: "test3", concurrency: :infinity}
+               %QueueManager.Queue{name: "test1", max_concurrency: :infinity},
+               %QueueManager.Queue{name: "test2", max_concurrency: 5},
+               %QueueManager.Queue{name: "test3", max_concurrency: :infinity}
              ]
     end
   end
@@ -42,7 +42,7 @@ defmodule FaktoryWorker.QueueManagerTest do
     test "should return a list of queues eligible to fetch on" do
       opts = [
         name: FaktoryWorker,
-        worker_pool: [queues: ["test1", {"test2", concurrency: 5}, "test3"]]
+        worker_pool: [queues: ["test1", {"test2", max_concurrency: 5}, "test3"]]
       ]
 
       {:ok, pid} = QueueManager.start_link(opts)
@@ -52,8 +52,11 @@ defmodule FaktoryWorker.QueueManagerTest do
       assert queues == ["test1", "test2", "test3"]
     end
 
-    test "should update the concurrency state when checking out a queue" do
-      opts = [name: FaktoryWorker, worker_pool: [queues: ["test1", {"test2", concurrency: 5}]]]
+    test "should update the max concurrency state when checking out a queue" do
+      opts = [
+        name: FaktoryWorker,
+        worker_pool: [queues: ["test1", {"test2", max_concurrency: 5}]]
+      ]
 
       {:ok, pid} = QueueManager.start_link(opts)
 
@@ -63,13 +66,16 @@ defmodule FaktoryWorker.QueueManagerTest do
       assert queues == ["test1", "test2"]
 
       assert state == [
-               %QueueManager.Queue{name: "test1", concurrency: :infinity},
-               %QueueManager.Queue{name: "test2", concurrency: 4}
+               %QueueManager.Queue{name: "test1", max_concurrency: :infinity},
+               %QueueManager.Queue{name: "test2", max_concurrency: 4}
              ]
     end
 
-    test "should not return a queue when the concurrency reaches 0" do
-      opts = [name: FaktoryWorker, worker_pool: [queues: ["test1", {"test2", concurrency: 1}]]]
+    test "should not return a queue when the max concurrency reaches 0" do
+      opts = [
+        name: FaktoryWorker,
+        worker_pool: [queues: ["test1", {"test2", max_concurrency: 1}]]
+      ]
 
       {:ok, pid} = QueueManager.start_link(opts)
 
@@ -82,15 +88,18 @@ defmodule FaktoryWorker.QueueManagerTest do
       assert queues_result2 == ["test1"]
 
       assert state == [
-               %QueueManager.Queue{name: "test1", concurrency: :infinity},
-               %QueueManager.Queue{name: "test2", concurrency: 0}
+               %QueueManager.Queue{name: "test1", max_concurrency: :infinity},
+               %QueueManager.Queue{name: "test2", max_concurrency: 0}
              ]
     end
   end
 
   describe "checkin_queues/2" do
-    test "it should update the queues concurrency counts when checking in a queue with a concurrency set" do
-      opts = [name: FaktoryWorker, worker_pool: [queues: ["test1", {"test2", concurrency: 1}]]]
+    test "it should update the queues max concurrency counts when checking in a queue with a max concurrency set" do
+      opts = [
+        name: FaktoryWorker,
+        worker_pool: [queues: ["test1", {"test2", max_concurrency: 1}]]
+      ]
 
       {:ok, pid} = QueueManager.start_link(opts)
 
@@ -99,13 +108,16 @@ defmodule FaktoryWorker.QueueManagerTest do
       state = :sys.get_state(pid)
 
       assert state == [
-               %QueueManager.Queue{name: "test1", concurrency: :infinity},
-               %QueueManager.Queue{name: "test2", concurrency: 2}
+               %QueueManager.Queue{name: "test1", max_concurrency: :infinity},
+               %QueueManager.Queue{name: "test2", max_concurrency: 2}
              ]
     end
 
-    test "it should not update the concurrency value when the queue is not checked in" do
-      opts = [name: FaktoryWorker, worker_pool: [queues: ["test1", {"test2", concurrency: 1}]]]
+    test "it should not update the max concurrency value when the queue is not checked in" do
+      opts = [
+        name: FaktoryWorker,
+        worker_pool: [queues: ["test1", {"test2", max_concurrency: 1}]]
+      ]
 
       {:ok, pid} = QueueManager.start_link(opts)
 
@@ -114,8 +126,8 @@ defmodule FaktoryWorker.QueueManagerTest do
       state = :sys.get_state(pid)
 
       assert state == [
-               %QueueManager.Queue{name: "test1", concurrency: :infinity},
-               %QueueManager.Queue{name: "test2", concurrency: 1}
+               %QueueManager.Queue{name: "test1", max_concurrency: :infinity},
+               %QueueManager.Queue{name: "test2", max_concurrency: 1}
              ]
     end
   end

--- a/test/faktory_worker/queue_manager_test.exs
+++ b/test/faktory_worker/queue_manager_test.exs
@@ -1,0 +1,122 @@
+defmodule FaktoryWorker.QueueManagerTest do
+  use ExUnit.Case
+
+  alias FaktoryWorker.QueueManager
+
+  describe "start_link/1" do
+    test "should start the queue manager" do
+      opts = [name: FaktoryWorker]
+
+      {:ok, pid} = QueueManager.start_link(opts)
+
+      assert pid == Process.whereis(FaktoryWorker_queue_manager)
+
+      :ok = Supervisor.stop(pid)
+    end
+
+    test "should set the queues state" do
+      opts = [
+        name: FaktoryWorker,
+        worker_pool: [queues: ["test1", {"test2", concurrency: 5}, "test3"]]
+      ]
+
+      {:ok, pid} = QueueManager.start_link(opts)
+
+      state = :sys.get_state(pid)
+
+      assert state == [
+               %QueueManager.Queue{name: "test1", concurrency: :infinity},
+               %QueueManager.Queue{name: "test2", concurrency: 5},
+               %QueueManager.Queue{name: "test3", concurrency: :infinity}
+             ]
+    end
+  end
+
+  describe "format_queue_manager_name/1" do
+    test "should return the given name with the queue manager suffix" do
+      assert :test_queue_manager == QueueManager.format_queue_manager_name(:test)
+    end
+  end
+
+  describe "checkout_queues/1" do
+    test "should return a list of queues eligible to fetch on" do
+      opts = [
+        name: FaktoryWorker,
+        worker_pool: [queues: ["test1", {"test2", concurrency: 5}, "test3"]]
+      ]
+
+      {:ok, pid} = QueueManager.start_link(opts)
+
+      queues = QueueManager.checkout_queues(pid)
+
+      assert queues == ["test1", "test2", "test3"]
+    end
+
+    test "should update the concurrency state when checking out a queue" do
+      opts = [name: FaktoryWorker, worker_pool: [queues: ["test1", {"test2", concurrency: 5}]]]
+
+      {:ok, pid} = QueueManager.start_link(opts)
+
+      queues = QueueManager.checkout_queues(pid)
+      state = :sys.get_state(pid)
+
+      assert queues == ["test1", "test2"]
+
+      assert state == [
+               %QueueManager.Queue{name: "test1", concurrency: :infinity},
+               %QueueManager.Queue{name: "test2", concurrency: 4}
+             ]
+    end
+
+    test "should not return a queue when the concurrency reaches 0" do
+      opts = [name: FaktoryWorker, worker_pool: [queues: ["test1", {"test2", concurrency: 1}]]]
+
+      {:ok, pid} = QueueManager.start_link(opts)
+
+      queues_result1 = QueueManager.checkout_queues(pid)
+      queues_result2 = QueueManager.checkout_queues(pid)
+
+      state = :sys.get_state(pid)
+
+      assert queues_result1 == ["test1", "test2"]
+      assert queues_result2 == ["test1"]
+
+      assert state == [
+               %QueueManager.Queue{name: "test1", concurrency: :infinity},
+               %QueueManager.Queue{name: "test2", concurrency: 0}
+             ]
+    end
+  end
+
+  describe "checkin_queues/2" do
+    test "it should update the queues concurrency counts when checking in a queue with a concurrency set" do
+      opts = [name: FaktoryWorker, worker_pool: [queues: ["test1", {"test2", concurrency: 1}]]]
+
+      {:ok, pid} = QueueManager.start_link(opts)
+
+      :ok = QueueManager.checkin_queues(pid, ["test1", "test2"])
+
+      state = :sys.get_state(pid)
+
+      assert state == [
+               %QueueManager.Queue{name: "test1", concurrency: :infinity},
+               %QueueManager.Queue{name: "test2", concurrency: 2}
+             ]
+    end
+
+    test "it should not update the concurrency value when the queue is not checked in" do
+      opts = [name: FaktoryWorker, worker_pool: [queues: ["test1", {"test2", concurrency: 1}]]]
+
+      {:ok, pid} = QueueManager.start_link(opts)
+
+      :ok = QueueManager.checkin_queues(pid, ["test1"])
+
+      state = :sys.get_state(pid)
+
+      assert state == [
+               %QueueManager.Queue{name: "test1", concurrency: :infinity},
+               %QueueManager.Queue{name: "test2", concurrency: 1}
+             ]
+    end
+  end
+end

--- a/test/faktory_worker/worker/server_integration_test.exs
+++ b/test/faktory_worker/worker/server_integration_test.exs
@@ -14,7 +14,6 @@ defmodule FaktoryWorker.Worker.ServerIntegrationTest do
       opts = [
         name: :test_worker_1,
         process_wid: Random.process_wid(),
-        queues: ["test_queue"],
         disable_fetch: true
       ]
 

--- a/test/faktory_worker/worker/server_test.exs
+++ b/test/faktory_worker/worker/server_test.exs
@@ -110,7 +110,7 @@ defmodule FaktoryWorker.Worker.ServerTest do
 
   describe "terminate/2" do
     test "should check in the queues with the queue manager" do
-      worker_pool = [queues: [{"test_queue", concurrency: 1}]]
+      worker_pool = [queues: [{"test_queue", max_concurrency: 1}]]
 
       pid = start_supervised!({QueueManager, name: FaktoryWorker, worker_pool: worker_pool})
 
@@ -121,8 +121,8 @@ defmodule FaktoryWorker.Worker.ServerTest do
 
       manager_state_after = :sys.get_state(pid)
 
-      assert manager_state_before == [%QueueManager.Queue{name: "test_queue", concurrency: 0}]
-      assert manager_state_after == [%QueueManager.Queue{name: "test_queue", concurrency: 1}]
+      assert manager_state_before == [%QueueManager.Queue{name: "test_queue", max_concurrency: 0}]
+      assert manager_state_after == [%QueueManager.Queue{name: "test_queue", max_concurrency: 1}]
     end
 
     test "should successfully terminate when queues is set to nil" do

--- a/test/faktory_worker/worker_test.exs
+++ b/test/faktory_worker/worker_test.exs
@@ -940,7 +940,7 @@ defmodule FaktoryWorker.WorkerTest do
 
   describe "checkin_queues/1" do
     test "should checkin the queues with the queue manager" do
-      worker_pool = [queues: [{"test_queue", concurrency: 1}]]
+      worker_pool = [queues: [{"test_queue", max_concurrency: 1}]]
 
       pid = start_supervised!({QueueManager, name: FaktoryWorker, worker_pool: worker_pool})
 
@@ -951,12 +951,12 @@ defmodule FaktoryWorker.WorkerTest do
 
       manager_state_after = :sys.get_state(pid)
 
-      assert manager_state_before == [%QueueManager.Queue{name: "test_queue", concurrency: 0}]
-      assert manager_state_after == [%QueueManager.Queue{name: "test_queue", concurrency: 1}]
+      assert manager_state_before == [%QueueManager.Queue{name: "test_queue", max_concurrency: 0}]
+      assert manager_state_after == [%QueueManager.Queue{name: "test_queue", max_concurrency: 1}]
     end
 
     test "should return ok when queues are nil" do
-      worker_pool = [queues: [{"test_queue", concurrency: 1}]]
+      worker_pool = [queues: [{"test_queue", max_concurrency: 1}]]
 
       pid = start_supervised!({QueueManager, name: FaktoryWorker, worker_pool: worker_pool})
 
@@ -967,8 +967,8 @@ defmodule FaktoryWorker.WorkerTest do
 
       manager_state_after = :sys.get_state(pid)
 
-      assert manager_state_before == [%QueueManager.Queue{name: "test_queue", concurrency: 1}]
-      assert manager_state_after == [%QueueManager.Queue{name: "test_queue", concurrency: 1}]
+      assert manager_state_before == [%QueueManager.Queue{name: "test_queue", max_concurrency: 1}]
+      assert manager_state_after == [%QueueManager.Queue{name: "test_queue", max_concurrency: 1}]
     end
   end
 

--- a/test/faktory_worker/worker_test.exs
+++ b/test/faktory_worker/worker_test.exs
@@ -7,6 +7,7 @@ defmodule FaktoryWorker.WorkerTest do
 
   alias FaktoryWorker.Worker
   alias FaktoryWorker.Random
+  alias FaktoryWorker.QueueManager
 
   setup :set_mox_global
   setup :verify_on_exit!
@@ -14,13 +15,13 @@ defmodule FaktoryWorker.WorkerTest do
   describe "new/2" do
     test "should return a worker struct" do
       process_wid = Random.process_wid()
-      opts = [process_wid: process_wid, queues: ["test_queue", "test_queue_two"]]
+      opts = [process_wid: process_wid]
 
       worker = Worker.new(opts)
 
       assert worker.process_wid == process_wid
       assert worker.worker_state == :ok
-      assert worker.queues == ["test_queue", "test_queue_two"]
+      assert worker.queues == nil
       assert worker.job_ref == nil
       assert worker.job_id == nil
       assert worker.job_timeout_ref == nil
@@ -32,20 +33,11 @@ defmodule FaktoryWorker.WorkerTest do
       end
     end
 
-    test "should raise if no queues is provided" do
-      opts = [process_wid: Random.process_wid()]
-
-      assert_raise KeyError, "key :queues not found in: #{inspect(opts)}", fn ->
-        Worker.new(opts)
-      end
-    end
-
     test "should open a new worker connection" do
       worker_connection_mox()
 
       opts = [
         process_wid: Random.process_wid(),
-        queues: ["test_queue"],
         connection: [socket_handler: FaktoryWorker.SocketMock]
       ]
 
@@ -55,7 +47,7 @@ defmodule FaktoryWorker.WorkerTest do
     end
 
     test "should schedule a fetch to be triggered" do
-      opts = [process_wid: Random.process_wid(), queues: ["test_queue"]]
+      opts = [process_wid: Random.process_wid()]
 
       Worker.new(opts)
 
@@ -65,6 +57,9 @@ defmodule FaktoryWorker.WorkerTest do
 
   describe "send_fetch/1" do
     test "should send a fetch command and schedule next fetch when state is ':ok'" do
+      worker_pool = [queues: ["test_queue"]]
+
+      start_supervised!({QueueManager, name: FaktoryWorker, worker_pool: worker_pool})
       start_supervised!({FaktoryWorker.JobSupervisor, name: FaktoryWorker})
 
       worker_connection_mox()
@@ -79,7 +74,6 @@ defmodule FaktoryWorker.WorkerTest do
 
       opts = [
         process_wid: Random.process_wid(),
-        queues: ["test_queue"],
         connection: [socket_handler: FaktoryWorker.SocketMock]
       ]
 
@@ -97,7 +91,6 @@ defmodule FaktoryWorker.WorkerTest do
 
       opts = [
         process_wid: Random.process_wid(),
-        queues: ["test_queue"],
         connection: [socket_handler: FaktoryWorker.SocketMock]
       ]
 
@@ -116,7 +109,6 @@ defmodule FaktoryWorker.WorkerTest do
 
       opts = [
         process_wid: Random.process_wid(),
-        queues: ["test_queue"],
         connection: [socket_handler: FaktoryWorker.SocketMock]
       ]
 
@@ -135,7 +127,6 @@ defmodule FaktoryWorker.WorkerTest do
 
       opts = [
         process_wid: Random.process_wid(),
-        queues: ["test_queue"],
         connection: [socket_handler: FaktoryWorker.SocketMock]
       ]
 
@@ -150,6 +141,9 @@ defmodule FaktoryWorker.WorkerTest do
     end
 
     test "should start the fetch command in a new process" do
+      worker_pool = [queues: ["test_queue"]]
+
+      start_supervised!({QueueManager, name: FaktoryWorker, worker_pool: worker_pool})
       start_supervised!({FaktoryWorker.JobSupervisor, name: FaktoryWorker})
 
       job =
@@ -178,7 +172,6 @@ defmodule FaktoryWorker.WorkerTest do
 
       opts = [
         process_wid: Random.process_wid(),
-        queues: ["test_queue"],
         connection: [socket_handler: FaktoryWorker.SocketMock]
       ]
 
@@ -193,6 +186,9 @@ defmodule FaktoryWorker.WorkerTest do
     end
 
     test "should send a fetch command with multiple queues" do
+      worker_pool = [queues: ["test_queue", "default"]]
+
+      start_supervised!({QueueManager, name: FaktoryWorker, worker_pool: worker_pool})
       start_supervised!({FaktoryWorker.JobSupervisor, name: FaktoryWorker})
 
       worker_connection_mox()
@@ -207,7 +203,6 @@ defmodule FaktoryWorker.WorkerTest do
 
       opts = [
         process_wid: Random.process_wid(),
-        queues: ["test_queue", "default"],
         connection: [socket_handler: FaktoryWorker.SocketMock]
       ]
 
@@ -218,6 +213,39 @@ defmodule FaktoryWorker.WorkerTest do
       consume_initial_fetch_message()
 
       assert_receive :fetch
+    end
+
+    test "should maintain the queues between fetches that do not return a job" do
+      worker_pool = [queues: ["test_queue", "default"]]
+
+      start_supervised!({QueueManager, name: FaktoryWorker, worker_pool: worker_pool})
+      start_supervised!({FaktoryWorker.JobSupervisor, name: FaktoryWorker})
+
+      worker_connection_mox()
+
+      expect(FaktoryWorker.SocketMock, :send, fn _, "FETCH test_queue default\r\n" ->
+        :ok
+      end)
+
+      expect(FaktoryWorker.SocketMock, :recv, fn _ ->
+        {:ok, "$-1\r\n"}
+      end)
+
+      opts = [
+        process_wid: Random.process_wid(),
+        connection: [socket_handler: FaktoryWorker.SocketMock]
+      ]
+
+      state =
+        opts
+        |> Worker.new()
+        |> Worker.send_fetch()
+
+      consume_initial_fetch_message()
+
+      state = Worker.send_fetch(state)
+
+      assert state.queues == ["test_queue", "default"]
     end
   end
 
@@ -253,7 +281,6 @@ defmodule FaktoryWorker.WorkerTest do
 
       opts = [
         process_wid: Random.process_wid(),
-        queues: ["timeout_queue"],
         connection: [socket_handler: FaktoryWorker.SocketMock]
       ]
 
@@ -290,7 +317,6 @@ defmodule FaktoryWorker.WorkerTest do
 
       opts = [
         process_wid: Random.process_wid(),
-        queues: ["timeout_queue"],
         connection: [socket_handler: FaktoryWorker.SocketMock]
       ]
 
@@ -316,7 +342,6 @@ defmodule FaktoryWorker.WorkerTest do
 
       opts = [
         process_wid: Random.process_wid(),
-        queues: ["timeout_queue"],
         connection: [socket_handler: FaktoryWorker.SocketMock]
       ]
 
@@ -337,7 +362,6 @@ defmodule FaktoryWorker.WorkerTest do
 
       opts = [
         process_wid: Random.process_wid(),
-        queues: ["timeout_queue"],
         connection: [socket_handler: FaktoryWorker.SocketMock]
       ]
 
@@ -362,7 +386,6 @@ defmodule FaktoryWorker.WorkerTest do
 
       opts = [
         process_wid: Random.process_wid(),
-        queues: ["timeout_queue"],
         connection: [socket_handler: FaktoryWorker.SocketMock]
       ]
 
@@ -433,7 +456,6 @@ defmodule FaktoryWorker.WorkerTest do
 
       opts = [
         process_wid: Random.process_wid(),
-        queues: ["test_queue"],
         retry_interval: 1,
         connection: [socket_handler: FaktoryWorker.SocketMock]
       ]
@@ -464,7 +486,6 @@ defmodule FaktoryWorker.WorkerTest do
 
       opts = [
         process_wid: Random.process_wid(),
-        queues: ["test_queue"],
         retry_interval: 1,
         connection: [socket_handler: FaktoryWorker.SocketMock]
       ]
@@ -521,7 +542,6 @@ defmodule FaktoryWorker.WorkerTest do
 
       opts = [
         process_wid: Random.process_wid(),
-        queues: ["test_queue"],
         connection: [socket_handler: FaktoryWorker.SocketMock]
       ]
 
@@ -562,7 +582,6 @@ defmodule FaktoryWorker.WorkerTest do
 
       opts = [
         process_wid: Random.process_wid(),
-        queues: ["test_queue"],
         connection: [socket_handler: FaktoryWorker.SocketMock]
       ]
 
@@ -594,7 +613,6 @@ defmodule FaktoryWorker.WorkerTest do
 
       opts = [
         process_wid: Random.process_wid(),
-        queues: ["test_queue"],
         connection: [socket_handler: FaktoryWorker.SocketMock]
       ]
 
@@ -632,7 +650,6 @@ defmodule FaktoryWorker.WorkerTest do
 
       opts = [
         process_wid: Random.process_wid(),
-        queues: ["test_queue"],
         disable_fetch: true,
         connection: [socket_handler: FaktoryWorker.SocketMock]
       ]
@@ -686,7 +703,6 @@ defmodule FaktoryWorker.WorkerTest do
 
       opts = [
         process_wid: Random.process_wid(),
-        queues: ["test_queue"],
         disable_fetch: true,
         connection: [socket_handler: FaktoryWorker.SocketMock]
       ]
@@ -730,7 +746,6 @@ defmodule FaktoryWorker.WorkerTest do
 
       opts = [
         process_wid: Random.process_wid(),
-        queues: ["test_queue"],
         connection: [socket_handler: FaktoryWorker.SocketMock]
       ]
 
@@ -772,7 +787,6 @@ defmodule FaktoryWorker.WorkerTest do
 
       opts = [
         process_wid: Random.process_wid(),
-        queues: ["test_queue"],
         connection: [socket_handler: FaktoryWorker.SocketMock]
       ]
 
@@ -827,7 +841,6 @@ defmodule FaktoryWorker.WorkerTest do
 
       opts = [
         process_wid: Random.process_wid(),
-        queues: ["test_queue"],
         connection: [socket_handler: FaktoryWorker.SocketMock]
       ]
 
@@ -864,7 +877,6 @@ defmodule FaktoryWorker.WorkerTest do
 
       opts = [
         process_wid: Random.process_wid(),
-        queues: ["test_queue"],
         disable_fetch: true,
         connection: [socket_handler: FaktoryWorker.SocketMock]
       ]
@@ -908,7 +920,6 @@ defmodule FaktoryWorker.WorkerTest do
 
       opts = [
         process_wid: Random.process_wid(),
-        queues: ["test_queue"],
         disable_fetch: true,
         connection: [socket_handler: FaktoryWorker.SocketMock]
       ]
@@ -924,6 +935,40 @@ defmodule FaktoryWorker.WorkerTest do
 
       assert result.job_timeout_ref == nil
       assert Process.cancel_timer(timer_ref) == false
+    end
+  end
+
+  describe "checkin_queues/1" do
+    test "should checkin the queues with the queue manager" do
+      worker_pool = [queues: [{"test_queue", concurrency: 1}]]
+
+      pid = start_supervised!({QueueManager, name: FaktoryWorker, worker_pool: worker_pool})
+
+      state = %{faktory_name: FaktoryWorker, queues: QueueManager.checkout_queues(pid)}
+      manager_state_before = :sys.get_state(pid)
+
+      Worker.checkin_queues(state)
+
+      manager_state_after = :sys.get_state(pid)
+
+      assert manager_state_before == [%QueueManager.Queue{name: "test_queue", concurrency: 0}]
+      assert manager_state_after == [%QueueManager.Queue{name: "test_queue", concurrency: 1}]
+    end
+
+    test "should return ok when queues are nil" do
+      worker_pool = [queues: [{"test_queue", concurrency: 1}]]
+
+      pid = start_supervised!({QueueManager, name: FaktoryWorker, worker_pool: worker_pool})
+
+      state = %{faktory_name: FaktoryWorker, queues: nil}
+      manager_state_before = :sys.get_state(pid)
+
+      :ok = Worker.checkin_queues(state)
+
+      manager_state_after = :sys.get_state(pid)
+
+      assert manager_state_before == [%QueueManager.Queue{name: "test_queue", concurrency: 1}]
+      assert manager_state_after == [%QueueManager.Queue{name: "test_queue", concurrency: 1}]
     end
   end
 

--- a/test/faktory_worker_test.exs
+++ b/test/faktory_worker_test.exs
@@ -19,6 +19,7 @@ defmodule FaktoryWorkerTest do
       config = get_child_spec_config(child_spec)
 
       assert config == [
+               {FaktoryWorker.QueueManager, [name: :my_test_faktory]},
                {FaktoryWorker.Pool, [name: :my_test_faktory]},
                {FaktoryWorker.PushPipeline, [name: :my_test_faktory]},
                {FaktoryWorker.JobSupervisor, [name: :my_test_faktory]},
@@ -37,6 +38,7 @@ defmodule FaktoryWorkerTest do
       config = get_child_spec_config(child_spec)
 
       assert config == [
+               {FaktoryWorker.QueueManager, [name: FaktoryWorker, pool: [size: 25]]},
                {FaktoryWorker.Pool, [name: FaktoryWorker, pool: [size: 25]]},
                {FaktoryWorker.PushPipeline, [name: FaktoryWorker, pool: [size: 25]]},
                {FaktoryWorker.JobSupervisor, [name: FaktoryWorker, pool: [size: 25]]},
@@ -56,6 +58,8 @@ defmodule FaktoryWorkerTest do
       config = get_child_spec_config(child_spec)
 
       assert config == [
+               {FaktoryWorker.QueueManager,
+                [name: FaktoryWorker, connection: [host: "somehost", port: 7519]]},
                {FaktoryWorker.Pool,
                 [name: FaktoryWorker, connection: [host: "somehost", port: 7519]]},
                {FaktoryWorker.PushPipeline,
@@ -75,6 +79,7 @@ defmodule FaktoryWorkerTest do
         {Supervisor, :start_link,
          [
            [
+             {FaktoryWorker.QueueManager, [name: FaktoryWorker]},
              {FaktoryWorker.Pool, [name: FaktoryWorker]},
              {FaktoryWorker.PushPipeline, [name: FaktoryWorker]},
              {FaktoryWorker.JobSupervisor, [name: FaktoryWorker]},


### PR DESCRIPTION
Allows a concurrency setting to be supplied along with the queue name to support limiting how many jobs should be handled concurrently for that queue.

This is a fairly basic implementation of queue management and can be improved with more advanced features such as tracking which worker has which queue to allow it to monitor workers and auto checkin queues if a worker goes down unexpectedly.

I wasn't sure on how to structure the config for this, so I have gone with the smallest change to the existing config and we can alter it if needed.

This will now allow two types of values (a binary or two element tuple) to be specified in the worker pool queues list which would look something like this.

```
{FaktoryWorker,
  worker_pool: [
     size: 100,
     queues: [
       "test_queue",
       {"limited_queue", max_concurrency: 5}
     ]
  ]}
```