### PR TITLE
Remove retry default now this is fixed in Faktory 1.0

### DIFF
--- a/lib/faktory_worker/job.ex
+++ b/lib/faktory_worker/job.ex
@@ -12,10 +12,6 @@ defmodule FaktoryWorker.Job do
   # created_at
   @optional_job_fields [:queue, :custom, :retry, :reserve_for]
 
-  @default_worker_config [
-    retry: 25
-  ]
-
   defmacro __using__(using_opts \\ []) do
     alias FaktoryWorker.Job
 
@@ -32,8 +28,6 @@ defmodule FaktoryWorker.Job do
 
   @doc false
   def build_payload(worker_module, job, opts) when is_list(job) do
-    opts = Keyword.merge(@default_worker_config, opts)
-
     %{
       jid: Random.job_id(),
       jobtype: job_type_for_module(worker_module),

--- a/test/faktory_worker/job/job_test.exs
+++ b/test/faktory_worker/job/job_test.exs
@@ -101,14 +101,6 @@ defmodule FaktoryWorker.Job.JobTest do
       assert job.retry == 20
     end
 
-    test "should set the default retry value" do
-      data = %{hey: "there!"}
-
-      job = Job.build_payload(Test.Worker, data, [])
-
-      assert job.retry == 25
-    end
-
     test "should not be able to specify invalid data for the retry field" do
       data = %{hey: "there!"}
       opts = [retry: "20"]


### PR DESCRIPTION
The retry issue was fixed in Faktory v1.0, therefore we no longer need to set this as a default.

Fixes #68 